### PR TITLE
Add generated skills index manifest

### DIFF
--- a/.github/scripts/build-skills-index.js
+++ b/.github/scripts/build-skills-index.js
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const ROOT = process.cwd();
+const OUT_FILE = path.join(ROOT, 'skills-index.json');
+const REPO_OWNER = process.env.SKILLS_INDEX_REPO_OWNER || 'Lonsdale201';
+const REPO_NAME = process.env.SKILLS_INDEX_REPO_NAME || 'wp-agent-skills';
+const REPO_REF = process.env.SKILLS_INDEX_REF || 'main';
+const CHECK_ONLY = process.argv.includes('--check');
+
+const ROOT_DIRS_TO_IGNORE = new Set([
+  '.git',
+  '.github',
+  '.idea',
+  '.vscode',
+  'node_modules',
+]);
+
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+function relativePath(filePath) {
+  return toPosixPath(path.relative(ROOT, filePath));
+}
+
+function readUtf8(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function sha256(text) {
+  return crypto.createHash('sha256').update(text, 'utf8').digest('hex');
+}
+
+function lineCount(text) {
+  if (text === '') {
+    return 0;
+  }
+  return text.replace(/\r\n?/g, '\n').split('\n').length;
+}
+
+function parseFrontmatter(content, skillPath) {
+  const normalized = content.replace(/\r\n?/g, '\n');
+  if (!normalized.startsWith('---\n')) {
+    throw new Error(`${skillPath}: file must start with YAML frontmatter.`);
+  }
+
+  const end = normalized.indexOf('\n---\n', 4);
+  if (end === -1) {
+    throw new Error(`${skillPath}: frontmatter is missing a closing --- line.`);
+  }
+
+  const yamlText = normalized.slice(4, end);
+  const body = normalized.slice(end + 5).replace(/^\n/, '');
+  let data;
+
+  try {
+    data = yaml.load(yamlText) || {};
+  } catch (error) {
+    data = parseLooseFrontmatter(yamlText);
+  }
+
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error(`${skillPath}: frontmatter must parse to an object.`);
+  }
+
+  return { data, body };
+}
+
+function parseLooseFrontmatter(yamlText) {
+  const data = {};
+  const lines = yamlText.split('\n');
+  let currentKey = null;
+  let blockKey = null;
+  let blockLines = [];
+
+  function finishBlock() {
+    if (blockKey !== null) {
+      data[blockKey] = blockLines.join('\n').trimEnd();
+      blockKey = null;
+      blockLines = [];
+    }
+  }
+
+  for (const line of lines) {
+    if (blockKey !== null) {
+      if (/^\s+/.test(line) || line.trim() === '') {
+        blockLines.push(line.replace(/^\s{2}/, ''));
+        continue;
+      }
+      finishBlock();
+    }
+
+    const topLevel = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (topLevel) {
+      currentKey = topLevel[1];
+      let value = topLevel[2].trim();
+
+      if (value === '|' || value === '>') {
+        blockKey = currentKey;
+        blockLines = [];
+        data[currentKey] = '';
+        continue;
+      }
+
+      if (value === '') {
+        data[currentKey] = [];
+        continue;
+      }
+
+      data[currentKey] = unquoteScalar(value);
+      continue;
+    }
+
+    const listItem = line.match(/^\s*-\s*(.*)$/);
+    if (listItem && currentKey !== null) {
+      if (!Array.isArray(data[currentKey])) {
+        data[currentKey] = data[currentKey] ? [String(data[currentKey])] : [];
+      }
+      data[currentKey].push(unquoteScalar(listItem[1].trim()));
+      continue;
+    }
+
+    if (/^\s+/.test(line) && currentKey !== null && typeof data[currentKey] === 'string') {
+      data[currentKey] = `${data[currentKey]} ${line.trim()}`.trim();
+    }
+  }
+
+  finishBlock();
+  return data;
+}
+
+function unquoteScalar(value) {
+  if (
+    (value.startsWith('"') && value.endsWith('"'))
+    || (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+}
+
+function skillNameIsValid(name) {
+  return /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/.test(name) && !name.includes('--');
+}
+
+function walkFiles(dir) {
+  const files = [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(fullPath));
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function classifyResource(relPath) {
+  const basename = path.basename(relPath).toLowerCase();
+  const parts = relPath.split('/');
+
+  if (parts.includes('scripts')) {
+    return 'script';
+  }
+  if (parts.includes('examples')) {
+    return 'example';
+  }
+  if (parts.includes('references') || basename === 'reference.md') {
+    return 'reference';
+  }
+  if (parts.includes('assets')) {
+    return 'asset';
+  }
+  if (basename === 'readme.md') {
+    return 'readme';
+  }
+
+  return 'resource';
+}
+
+function resourceInfo(filePath, skillDir) {
+  const relToSkill = toPosixPath(path.relative(skillDir, filePath));
+  const relToRepo = relativePath(filePath);
+  const content = fs.readFileSync(filePath);
+
+  return {
+    path: relToSkill,
+    repo_path: relToRepo,
+    type: classifyResource(relToSkill),
+    bytes: content.length,
+    sha256: crypto.createHash('sha256').update(content).digest('hex'),
+  };
+}
+
+function rawUrl(repoPath) {
+  return `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/${REPO_REF}/${repoPath}`;
+}
+
+function htmlUrl(repoPath) {
+  return `https://github.com/${REPO_OWNER}/${REPO_NAME}/tree/${REPO_REF}/${repoPath}`;
+}
+
+function blobUrl(repoPath) {
+  return `https://github.com/${REPO_OWNER}/${REPO_NAME}/blob/${REPO_REF}/${repoPath}`;
+}
+
+function discoverDomainDirs() {
+  return fs.readdirSync(ROOT, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .filter((entry) => !ROOT_DIRS_TO_IGNORE.has(entry.name))
+    .map((entry) => entry.name)
+    .filter((domain) => {
+      const domainDir = path.join(ROOT, domain);
+      return fs.readdirSync(domainDir, { withFileTypes: true }).some((entry) => {
+        return entry.isDirectory() && fs.existsSync(path.join(domainDir, entry.name, 'SKILL.md'));
+      });
+    })
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function loadSkill(domain, slug) {
+  const skillDir = path.join(ROOT, domain, slug);
+  const skillMdPath = path.join(skillDir, 'SKILL.md');
+  const skillRepoPath = relativePath(skillMdPath);
+  const content = readUtf8(skillMdPath);
+  const { data, body } = parseFrontmatter(content, skillRepoPath);
+
+  const name = String(data.name || '').trim();
+  const description = String(data.description || '').trim();
+
+  if (!name) {
+    throw new Error(`${skillRepoPath}: missing required frontmatter field "name".`);
+  }
+  if (!description) {
+    throw new Error(`${skillRepoPath}: missing required frontmatter field "description".`);
+  }
+  if (!skillNameIsValid(name)) {
+    throw new Error(`${skillRepoPath}: "name" must be lowercase kebab-case, 1-64 chars, with no leading/trailing/consecutive hyphens.`);
+  }
+  if (name !== slug) {
+    throw new Error(`${skillRepoPath}: "name" (${name}) must match the folder name (${slug}).`);
+  }
+  if (body.trim() === '') {
+    throw new Error(`${skillRepoPath}: skill body is empty.`);
+  }
+
+  const metadata = { ...data };
+  delete metadata.name;
+  delete metadata.description;
+
+  const resources = walkFiles(skillDir)
+    .filter((filePath) => path.basename(filePath) !== 'SKILL.md')
+    .map((filePath) => resourceInfo(filePath, skillDir));
+
+  const resourceTypes = new Set(resources.map((resource) => resource.type));
+  const skillDirRepoPath = `${domain}/${slug}`;
+
+  return {
+    slug,
+    name,
+    domain,
+    description,
+    path: skillDirRepoPath,
+    skill_path: skillRepoPath,
+    url: rawUrl(skillRepoPath),
+    raw_url: rawUrl(skillRepoPath),
+    html_url: blobUrl(skillRepoPath),
+    directory_url: htmlUrl(skillDirRepoPath),
+    metadata,
+    resources,
+    has_reference: resourceTypes.has('reference'),
+    has_examples: resourceTypes.has('example'),
+    has_scripts: resourceTypes.has('script'),
+    skill_md: {
+      bytes: Buffer.byteLength(content, 'utf8'),
+      lines: lineCount(content),
+      sha256: sha256(content),
+    },
+  };
+}
+
+function buildIndex() {
+  const domains = discoverDomainDirs();
+  const skills = [];
+  const seen = new Map();
+
+  for (const domain of domains) {
+    const domainDir = path.join(ROOT, domain);
+    const slugs = fs.readdirSync(domainDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .filter((slug) => fs.existsSync(path.join(domainDir, slug, 'SKILL.md')))
+      .sort((a, b) => a.localeCompare(b));
+
+    for (const slug of slugs) {
+      const skill = loadSkill(domain, slug);
+      if (seen.has(skill.name)) {
+        throw new Error(`${skill.skill_path}: duplicate skill name "${skill.name}" also used by ${seen.get(skill.name)}.`);
+      }
+      seen.set(skill.name, skill.skill_path);
+      skills.push(skill);
+    }
+  }
+
+  const domainSummaries = domains.map((domain) => {
+    const readmePath = path.join(ROOT, domain, 'README.md');
+    return {
+      slug: domain,
+      path: domain,
+      readme_path: fs.existsSync(readmePath) ? `${domain}/README.md` : null,
+      skill_count: skills.filter((skill) => skill.domain === domain).length,
+    };
+  });
+
+  return {
+    $schema: 'https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/schemas/skills-index.v1.json',
+    schema_version: '1.0.0',
+    repository: {
+      owner: REPO_OWNER,
+      name: REPO_NAME,
+      url: `https://github.com/${REPO_OWNER}/${REPO_NAME}`,
+      ref: REPO_REF,
+    },
+    source: {
+      layout: '<domain>/<skill>/SKILL.md',
+      skill_file: 'SKILL.md',
+    },
+    domain_count: domainSummaries.length,
+    skill_count: skills.length,
+    domains: domainSummaries,
+    skills,
+  };
+}
+
+function stableJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function main() {
+  const json = stableJson(buildIndex());
+
+  if (CHECK_ONLY) {
+    if (!fs.existsSync(OUT_FILE)) {
+      console.error('skills-index.json is missing. Run: node .github/scripts/build-skills-index.js');
+      process.exit(1);
+    }
+
+    const current = readUtf8(OUT_FILE).replace(/\r\n?/g, '\n');
+    if (current !== json) {
+      console.error('skills-index.json is out of date. Run: node .github/scripts/build-skills-index.js');
+      process.exit(1);
+    }
+
+    console.log('skills-index.json is up to date.');
+    return;
+  }
+
+  fs.writeFileSync(OUT_FILE, json, 'utf8');
+  console.log(`Wrote ${relativePath(OUT_FILE)}.`);
+}
+
+main();

--- a/.github/scripts/validate-skill.js
+++ b/.github/scripts/validate-skill.js
@@ -296,6 +296,8 @@ function main() {
   // Path scope check
   const offlimits = files.filter((f) => {
     if (f.startsWith('.github/')) return false; // workflow / template edits validated by review only
+    if (f.startsWith('schemas/')) return false;
+    if (f === 'skills-index.json') return false;
     if (f === 'README.md' || f === 'CONTRIBUTING.md' || f === 'CHANGELOG.md' || f === 'SKILL_TEMPLATE.md' || f === 'LICENSE' || f === '.gitignore') return false;
     const top = f.split('/')[0];
     return !ALLOWED_DOMAINS.has(top);

--- a/.github/workflows/build-skills-index.yml
+++ b/.github/workflows/build-skills-index.yml
@@ -1,0 +1,33 @@
+name: Build skills index
+
+on:
+  pull_request:
+    branches: [contrib, main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - contrib
+      - main
+      - 'submission/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-index:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install deps
+        run: npm install --no-save --no-package-lock js-yaml@4
+
+      - name: Verify skills-index.json
+        run: node .github/scripts/build-skills-index.js --check

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -1,4 +1,4 @@
-name: Issue → Skill PR
+name: Issue to Skill PR
 
 on:
   issues:
@@ -19,6 +19,9 @@ jobs:
         with:
           ref: contrib
           fetch-depth: 0
+
+      - name: Install deps
+        run: npm install --no-save --no-package-lock js-yaml@4
 
       - name: Parse issue form
         id: parse
@@ -70,6 +73,7 @@ jobs:
           git checkout -B "$BRANCH" origin/contrib
           # Replay the new files (built by the script under .build/output/)
           rsync -a --delete-after .build/output/ ./
+          node .github/scripts/build-skills-index.js
           git add -A
           if git diff --cached --quiet; then
             echo "No changes to commit (idempotent re-run)."

--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ New domain folders follow the same convention: top-level folder per plugin (or p
 
 The folder layout is the source of truth — there is intentionally no flat list of every skill in this README. As the collection grows, the per-domain READMEs scale, this file does not.
 
+## Machine-readable index
+
+The repository also publishes [`skills-index.json`](skills-index.json), a generated catalog of every skill, its domain, description, source path, raw `SKILL.md` URL, frontmatter metadata, and bundled resource files.
+
+The index is intended for thin adapters, install scripts, websites, MCP servers, and other tooling that should not have to crawl the GitHub tree. It is generated from the folder layout:
+
+```bash
+npm install --no-save --no-package-lock js-yaml@4
+node .github/scripts/build-skills-index.js
+```
+
+CI checks that `skills-index.json` stays in sync with the committed `SKILL.md` files.
+
 ## Using these skills
 
 ### Claude Code

--- a/schemas/skills-index.v1.json
+++ b/schemas/skills-index.v1.json
@@ -1,0 +1,244 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/schemas/skills-index.v1.json",
+  "title": "WP Agent Skills Index",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "repository",
+    "source",
+    "domain_count",
+    "skill_count",
+    "domains",
+    "skills"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "schema_version": {
+      "type": "string"
+    },
+    "repository": {
+      "type": "object",
+      "required": [
+        "owner",
+        "name",
+        "url",
+        "ref"
+      ],
+      "properties": {
+        "owner": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "ref": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "source": {
+      "type": "object",
+      "required": [
+        "layout",
+        "skill_file"
+      ],
+      "properties": {
+        "layout": {
+          "type": "string"
+        },
+        "skill_file": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "domain_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "skill_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "domains": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "slug",
+          "path",
+          "readme_path",
+          "skill_count"
+        ],
+        "properties": {
+          "slug": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "readme_path": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "skill_count": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "skills": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "slug",
+          "name",
+          "domain",
+          "description",
+          "path",
+          "skill_path",
+          "url",
+          "raw_url",
+          "html_url",
+          "directory_url",
+          "metadata",
+          "resources",
+          "has_reference",
+          "has_examples",
+          "has_scripts",
+          "skill_md"
+        ],
+        "properties": {
+          "slug": {
+            "type": "string",
+            "pattern": "^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$"
+          },
+          "domain": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "skill_path": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "raw_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "html_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "directory_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "resources": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "path",
+                "repo_path",
+                "type",
+                "bytes",
+                "sha256"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "repo_path": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "asset",
+                    "example",
+                    "readme",
+                    "reference",
+                    "resource",
+                    "script"
+                  ]
+                },
+                "bytes": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "sha256": {
+                  "type": "string",
+                  "pattern": "^[a-f0-9]{64}$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "has_reference": {
+            "type": "boolean"
+          },
+          "has_examples": {
+            "type": "boolean"
+          },
+          "has_scripts": {
+            "type": "boolean"
+          },
+          "skill_md": {
+            "type": "object",
+            "required": [
+              "bytes",
+              "lines",
+              "sha256"
+            ],
+            "properties": {
+              "bytes": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "lines": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "sha256": {
+                "type": "string",
+                "pattern": "^[a-f0-9]{64}$"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/skills-index.json
+++ b/skills-index.json
@@ -1,0 +1,4666 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/schemas/skills-index.v1.json",
+  "schema_version": "1.0.0",
+  "repository": {
+    "owner": "Lonsdale201",
+    "name": "wp-agent-skills",
+    "url": "https://github.com/Lonsdale201/wp-agent-skills",
+    "ref": "main"
+  },
+  "source": {
+    "layout": "<domain>/<skill>/SKILL.md",
+    "skill_file": "SKILL.md"
+  },
+  "domain_count": 10,
+  "skill_count": 112,
+  "domains": [
+    {
+      "slug": "better-data",
+      "path": "better-data",
+      "readme_path": "better-data/README.md",
+      "skill_count": 10
+    },
+    {
+      "slug": "better-route",
+      "path": "better-route",
+      "readme_path": "better-route/README.md",
+      "skill_count": 22
+    },
+    {
+      "slug": "fluentcrm",
+      "path": "fluentcrm",
+      "readme_path": "fluentcrm/README.md",
+      "skill_count": 5
+    },
+    {
+      "slug": "jet-engine",
+      "path": "jet-engine",
+      "readme_path": "jet-engine/README.md",
+      "skill_count": 3
+    },
+    {
+      "slug": "jetformbuilder",
+      "path": "jetformbuilder",
+      "readme_path": "jetformbuilder/README.md",
+      "skill_count": 7
+    },
+    {
+      "slug": "lw-plugins",
+      "path": "lw-plugins",
+      "readme_path": "lw-plugins/README.md",
+      "skill_count": 6
+    },
+    {
+      "slug": "plugin-scaffold",
+      "path": "plugin-scaffold",
+      "readme_path": "plugin-scaffold/README.md",
+      "skill_count": 11
+    },
+    {
+      "slug": "woocommerce",
+      "path": "woocommerce",
+      "readme_path": "woocommerce/README.md",
+      "skill_count": 23
+    },
+    {
+      "slug": "wordpress",
+      "path": "wordpress",
+      "readme_path": "wordpress/README.md",
+      "skill_count": 23
+    },
+    {
+      "slug": "wp-rocket",
+      "path": "wp-rocket",
+      "readme_path": "wp-rocket/README.md",
+      "skill_count": 2
+    }
+  ],
+  "skills": [
+    {
+      "slug": "bd-attribute",
+      "name": "bd-attribute",
+      "domain": "better-data",
+      "description": "Add a new declarative attribute to the better-data library (e.g. #[ArrayOf], #[Default], domain hint). Attributes live in src/Attribute/ as final readonly classes with constructor-promoted public properties — pure data carriers, never business logic. The failure mode that catches every contributor is \"partial wiring\" — declaring the attribute and reading it in ONE engine (e.g. only PostSink) while leaving Presenter, RestSchemaBuilder, and AttributeDrivenHydrator untouched. Stress scenarios have caught this pattern repeatedly. Every relevant engine must know about the new attribute, otherwise it silently degrades on the unwired path. Use when adding any new #[Foo] attribute that DTO authors will sprinkle on parameters / properties. Triggers on creating a class in src/Attribute/, applying #[Attribute(...)], references to AttributeDrivenHydrator / SinkProjection::prepareValue / RestSchemaBuilder / Presenter::sensitiveFieldNames in the diff.",
+      "path": "better-data/bd-attribute",
+      "skill_path": "better-data/bd-attribute/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-attribute/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-attribute/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-data/bd-attribute/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-data/bd-attribute",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-data",
+        "plugin-version-tested": "phase-9",
+        "php-min": "8.3",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://github.com/lonsdale201/better-data"
+        ],
+        "source-refs": [
+          "src/Attribute/MetaKey.php",
+          "src/Attribute/PostField.php",
+          "src/Attribute/UserField.php",
+          "src/Attribute/TermField.php",
+          "src/Attribute/Column.php",
+          "src/Attribute/Sensitive.php",
+          "src/Attribute/Encrypted.php",
+          "src/Attribute/ListOf.php",
+          "src/Attribute/DateFormat.php",
+          "src/Internal/AttributeDrivenHydrator.php",
+          "src/Internal/SinkProjection.php",
+          "src/Internal/RestSchemaBuilder.php",
+          "src/Sink/OptionSink.php",
+          "src/Presenter/Presenter.php",
+          "src/DataObject.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 14588,
+        "lines": 306,
+        "sha256": "70815b3b9c46acd5515d5ab4d34d2da5ef45cdcc5ac1c8a42904c2d47f77b22f"
+      }
+    },
+    {
+      "slug": "bd-better-route-bridge",
+      "name": "bd-better-route-bridge",
+      "domain": "better-data",
+      "description": "Compose better-data DTOs with the better-route library — use BetterRouteBridge::{get, post, put, patch, delete} to register a REST route that hydrates the request into a DTO, validates, calls the handler with (DataObject, mixed $request), and presents returned DataObject values through Presenter with PresentationContext::rest(). Critical contract — the bridge is method-name based (talks to Router / RouteBuilder by duck-typing) so better-data does NOT take a hard Composer dependency on better-route. URL-owned fields go into routeFields option (e.g. ['id']) — those are merged from URL params AND rejected from JSON / body / query buckets via RequestParamCollisionException; this is the route-side equivalent of RequestSource::noCollision. Use when wiring DTO-backed REST endpoints, feeding DTO schemas into better-route's OpenAPI exporter, or moving request data from a route handler into a better-data DataObject. Triggers on BetterRouteBridge::get/post/put/patch/delete, routeFields, RequestParamCollisionException, OpenAPI / OpenApi DTO schema in better-data.",
+      "path": "better-data/bd-better-route-bridge",
+      "skill_path": "better-data/bd-better-route-bridge/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-better-route-bridge/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-better-route-bridge/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-data/bd-better-route-bridge/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-data/bd-better-route-bridge",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-data",
+        "plugin-version-tested": "phase-9",
+        "php-min": "8.3",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://github.com/lonsdale201/better-data",
+          "https://github.com/lonsdale201/better-route"
+        ],
+        "source-refs": [
+          "src/Route/BetterRouteBridge.php",
+          "src/Registration/MetaKeyRegistry.php",
+          "src/Source/RequestSource.php",
+          "src/Internal/RestSchemaBuilder.php",
+          "src/Presenter/Presenter.php",
+          "src/Presenter/PresentationContext.php",
+          "src/Exception/RequestParamCollisionException.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 16053,
+        "lines": 326,
+        "sha256": "7b28faf102045eeec19f07a58c063589a205ed2fca6cd024d09234244fd41aaf"
+      }
+    },
+    {
+      "slug": "bd-companion-plugin",
+      "name": "bd-companion-plugin",
+      "domain": "better-data",
+      "description": "Work on better-data-plugin-test — the companion plugin that exercises the better-data library against a live WordPress install. Plugin is intentionally NOT part of the library public API, so feel free to break its internals to demonstrate a point. Three test tiers — Smoke (regression; never tolerate FAIL), Stress (deep integration with OK/FAIL/NOTE findings — NOTE is for surfaced quirks worth documenting without blocking), and Admin pages (eyeball-level proof of behaviour, e.g. ShopSettingsPage rendering print_r($dto) to visually confirm Secret redaction). The Widget Shop fixture (bd_widget CPT + bd_order CPT + ShopSettingsDto) is the canonical realistic consumer; extend it rather than inventing a new fixture. CLI is the main driving surface — wp better-data {test, stress, seed, purge, inventory}. Use when changes go under wp-content/plugins/better-data-plugin-test/. Triggers on Smoke / Stress / Runner / Cli files in that path, \"wp better-data\" CLI invocations, \"smoke / stress scenario\" mentions.",
+      "path": "better-data/bd-companion-plugin",
+      "skill_path": "better-data/bd-companion-plugin/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-companion-plugin/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-companion-plugin/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-data/bd-companion-plugin/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-data/bd-companion-plugin",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-data",
+        "plugin-version-tested": "phase-9",
+        "php-min": "8.3",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://github.com/lonsdale201/better-data"
+        ],
+        "source-refs": [
+          "wp-content/plugins/better-data-plugin-test/better-data-plugin-test.php",
+          "wp-content/plugins/better-data-plugin-test/src/Plugin.php",
+          "wp-content/plugins/better-data-plugin-test/src/Cli.php",
+          "wp-content/plugins/better-data-plugin-test/src/StressCli.php",
+          "wp-content/plugins/better-data-plugin-test/src/SeedCli.php",
+          "wp-content/plugins/better-data-plugin-test/src/PurgeCli.php",
+          "wp-content/plugins/better-data-plugin-test/src/InventoryCli.php",
+          "wp-content/plugins/better-data-plugin-test/src/Smoke/Runner.php",
+          "wp-content/plugins/better-data-plugin-test/src/Smoke/Assertion.php",
+          "wp-content/plugins/better-data-plugin-test/src/Stress/Runner.php",
+          "wp-content/plugins/better-data-plugin-test/src/Stress/Finding.php",
+          "wp-content/plugins/better-data-plugin-test/src/Dto/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 15317,
+        "lines": 320,
+        "sha256": "aafef86b99166c213be7c2ac1436f0730da69ea2a9c6d711278e52aeb1e51845"
+      }
+    },
+    {
+      "slug": "bd-data-object",
+      "name": "bd-data-object",
+      "domain": "better-data",
+      "description": "Add or modify DataObject subclasses inside the better-data library — the immutable, attribute-decorated DTOs that the whole library is built around. Every DTO is final readonly class extends DataObject with constructor-promoted typed parameters; sources hydrate via ::fromArray, sinks project via SinkProjection, the Presenter renders via HasPresenter trait. Important — every trailing constructor parameter MUST have a default. Without it, PHP Reflection reports isDefaultValueAvailable=false on earlier params too, and DataObject throws MissingRequiredFieldException at hydration. Also Secret fields default to ?Secret = null (never new Secret('')), encrypt requires the Secret type, and DTOs never grow public mutators (use ->with([...])). Use when adding a new DTO (UserProfileDto, OrderDto, plugin fixture), adding fields to an existing DTO, or reviewing a PR that introduces a new class extending DataObject. Triggers on extends DataObject, DataObject::fromArray, ->with(), HasWpSources, HasWpSinks, HasPresenter, MissingRequiredFieldException, \"new DTO\" in better-data.",
+      "path": "better-data/bd-data-object",
+      "skill_path": "better-data/bd-data-object/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-data-object/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-data-object/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-data/bd-data-object/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-data/bd-data-object",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-data",
+        "plugin-version-tested": "phase-9",
+        "php-min": "8.3",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://github.com/lonsdale201/better-data"
+        ],
+        "source-refs": [
+          "src/DataObject.php",
+          "src/Internal/AttributeDrivenHydrator.php",
+          "src/Source/HasWpSources.php",
+          "src/Sink/HasWpSinks.php",
+          "src/Presenter/HasPresenter.php",
+          "src/Attribute/MetaKey.php",
+          "src/Attribute/PostField.php",
+          "src/Attribute/Encrypted.php",
+          "src/Attribute/Sensitive.php",
+          "src/Attribute/ListOf.php",
+          "src/Attribute/DateFormat.php",
+          "src/Validation/Rule/Required.php",
+          "src/Secret.php",
+          "src/Exception/MissingRequiredFieldException.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 16264,
+        "lines": 310,
+        "sha256": "e642c8dcf227198e75c8fe9d47bd4f9d567611630149ae4ee774647c11ee8209"
+      }
+    },
+    {
+      "slug": "bd-hydration-coercion",
+      "name": "bd-hydration-coercion",
+      "domain": "better-data",
+      "description": "Modify how raw values become typed property values in better-data — work in TypeCoercer (primitives + DateTime + Enum + Secret) or DataObject::coerceParameter (attribute-aware — ListOf, Encrypted, etc.). Critical layering — TypeCoercer is pure, must stay callable from a no-WordPress unit test, no side effects, no global reads, no WP function calls; attribute-driven coercion lives ABOVE TypeCoercer (read attribute → do the rich-type dance → optionally delegate to TypeCoercer with a simpler value). Use the explicit helpers (toString, toInt, toFloat, toBool, toArray, toEnum), never settype() / intval() / unchecked casts — and throw TypeCoercionException on anything surprising. Use when fixing a hydration bug, adding a new primitive coercion, or extending attribute-aware coercion. Triggers on changes to TypeCoercer.php, DataObject::coerceParameter, AttributeDrivenHydrator, TypeCoercionException, \"hydration bug\", \"fromArray throws\".",
+      "path": "better-data/bd-hydration-coercion",
+      "skill_path": "better-data/bd-hydration-coercion/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-hydration-coercion/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-hydration-coercion/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-data/bd-hydration-coercion/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-data/bd-hydration-coercion",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-data",
+        "plugin-version-tested": "phase-9",
+        "php-min": "8.3",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://github.com/lonsdale201/better-data"
+        ],
+        "source-refs": [
+          "src/Internal/TypeCoercer.php",
+          "src/DataObject.php",
+          "src/Internal/AttributeDrivenHydrator.php",
+          "src/Attribute/Encrypted.php",
+          "src/Attribute/ListOf.php",
+          "src/Encryption/EncryptionEngine.php",
+          "src/Exception/TypeCoercionException.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 14633,
+        "lines": 315,
+        "sha256": "17fd2b6f21850984fa0060e2daf14bbfd7e2643069fa437766f6685894cec8bb"
+      }
+    },
+    {
+      "slug": "bd-presenter",
+      "name": "bd-presenter",
+      "domain": "better-data",
+      "description": "Extend the better-data Presenter — add a fluent builder method (rename, mask, format, compute) or a PresentationContext flag. The Presenter is a mutable builder around a readonly DTO — each fluent method mutates internal state ($this->only, $this->hidden, $this->computed, etc.) and returns $this for chaining; the wrapped DataObject NEVER mutates. CollectionPresenter records every configurer as a closure on $this->configurers and replays them per item in toArray. Critical contract — any new method that emits values from the DTO MUST honor sensitiveFieldNames() (the Sensitive attribute + Secret type list); a method that bypasses redaction is a security regression. Localized strings need LocaleScope::runIn so withLocale() works. Use when adding mask, formatDate-like, hideIf, context-aware methods. Triggers on changes to Presenter.php / CollectionPresenter.php / PresentationContext.php / Formatter/.",
+      "path": "better-data/bd-presenter",
+      "skill_path": "better-data/bd-presenter/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-presenter/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-presenter/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-data/bd-presenter/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-data/bd-presenter",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-data",
+        "plugin-version-tested": "phase-9",
+        "php-min": "8.3",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://github.com/lonsdale201/better-data"
+        ],
+        "source-refs": [
+          "src/Presenter/Presenter.php",
+          "src/Presenter/CollectionPresenter.php",
+          "src/Presenter/PresentationContext.php",
+          "src/Presenter/HasPresenter.php",
+          "src/Presenter/Formatter/DateFormatter.php",
+          "src/Presenter/Formatter/CurrencyFormatter.php",
+          "src/Secret.php",
+          "src/Attribute/Sensitive.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 16375,
+        "lines": 328,
+        "sha256": "f2f661809dbe68a93e8e65bddf604aec9747cb2a20dc3fafb71a1261628e8cd6"
+      }
+    },
+    {
+      "slug": "bd-security",
+      "name": "bd-security",
+      "domain": "better-data",
+      "description": "Apply better-data's security discipline when touching Secret, EncryptionEngine, #[Sensitive], #[Encrypted], MetaKeyRegistry::register, RequestSource guards, or user_pass handling. Loud-over-silent — missing key throws, tampered ciphertext throws, unknown strict-whitelist field throws, colliding route-owned field throws; silent degradation is the worst outcome for security. Symmetric end-to-end — encrypt on write, decrypt on read; redact on toArray, reveal explicitly via $secret->reveal() inside compute() closures (the audit point); a new leak path needs a SecretTest leak probe. Never cache the raw key — EncryptionEngine re-reads BETTER_DATA_ENCRYPTION_KEY on every call so rotation works. Constant-time comparison — hash_equals, never == or ===. Use when any of those primitives is in the diff. Triggers on EncryptionEngine, Secret, Sensitive, Encrypted, RequestSource, BETTER_DATA_ENCRYPTION_KEY.",
+      "path": "better-data/bd-security",
+      "skill_path": "better-data/bd-security/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-security/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-security/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-data/bd-security/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-data/bd-security",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-data",
+        "plugin-version-tested": "phase-9",
+        "php-min": "8.3",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://github.com/lonsdale201/better-data"
+        ],
+        "source-refs": [
+          "src/Secret.php",
+          "src/Encryption/EncryptionEngine.php",
+          "src/Attribute/Encrypted.php",
+          "src/Attribute/Sensitive.php",
+          "src/Registration/MetaKeyRegistry.php",
+          "src/Source/RequestSource.php",
+          "src/DataObject.php",
+          "src/Exception/DecryptionFailedException.php",
+          "src/Exception/SecretSerializationException.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 16196,
+        "lines": 326,
+        "sha256": "d5758e5499a05980e54cea7c0da5aefbd8724f22fce07156433cd4f67c9a6512"
+      }
+    },
+    {
+      "slug": "bd-sink",
+      "name": "bd-sink",
+      "domain": "better-data",
+      "description": "Add a new sink to better-data — code that writes DataObjects back to a WordPress data store the library doesn't cover yet (comment meta, REST upload, custom taxonomy hierarchy). Mirror PostSink's two-mode shape — projection methods (toArgs / toMeta) return raw arrays for caller-managed writes, convenience methods (insert / update / save) commit everything internally and MUST pass values through wp_slash() because WP's write pipeline calls wp_unslash() on inbound data. Critical contract — null DTO value deletes the meta entry, non-null updates it; encryption MUST route through EncryptionEngine::encrypt symmetrically with the matching source's decrypt; never silently skip encryption (every Phase-8.7 OptionSink Secret bug came from asymmetric write/read). Use when integrating writes for a new WP store. Triggers on creating a class in src/Sink/, toArgs / toMeta / insert / update / save method shape, references to SinkProjection or wp_slash in the diff.",
+      "path": "better-data/bd-sink",
+      "skill_path": "better-data/bd-sink/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-sink/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-sink/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-data/bd-sink/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-data/bd-sink",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-data",
+        "plugin-version-tested": "phase-9",
+        "php-min": "8.3",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://github.com/lonsdale201/better-data"
+        ],
+        "source-refs": [
+          "src/Sink/HasWpSinks.php",
+          "src/Sink/PostSink.php",
+          "src/Sink/UserSink.php",
+          "src/Sink/TermSink.php",
+          "src/Sink/OptionSink.php",
+          "src/Sink/RowSink.php",
+          "src/Internal/SinkProjection.php",
+          "src/Encryption/EncryptionEngine.php",
+          "src/Exception/MissingIdentifierException.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 15548,
+        "lines": 333,
+        "sha256": "edcbadd0b9e56f68c5bae9a68a51ae9be99590ffa828762fa009837fd5f3807e"
+      }
+    },
+    {
+      "slug": "bd-source-adapter",
+      "name": "bd-source-adapter",
+      "domain": "better-data",
+      "description": "Add a new source adapter to better-data — code that reads from a WordPress data store the library doesn't cover yet (comments, attachments, transients, custom tables). Mirror the canonical shape PostSource / UserSource / TermSource use — a non-final class with static hydrate(int|object, $dtoClass) and hydrateMany(list<int>, $dtoClass) methods. Critical contract — the meta fetcher closure passed to the AttributeDrivenHydrator must return null when the meta key does not exist (use metadata_exists guard) and the stored value otherwise. Without this guard you cannot distinguish \"missing meta → use default\" from \"stored empty string → preserve emptiness\", and Reflection-default fallback breaks. Bulk hydration must prewarm caches with the equivalent of update_meta_cache + (where applicable) _prime_post_caches. Use when integrating a new WP store. Triggers on creating a class in src/Source/, hydrate / hydrateMany method signatures, references to AttributeDrivenHydrator from a source.",
+      "path": "better-data/bd-source-adapter",
+      "skill_path": "better-data/bd-source-adapter/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-source-adapter/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-source-adapter/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-data/bd-source-adapter/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-data/bd-source-adapter",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-data",
+        "plugin-version-tested": "phase-9",
+        "php-min": "8.3",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://github.com/lonsdale201/better-data"
+        ],
+        "source-refs": [
+          "src/Source/HasWpSources.php",
+          "src/Source/PostSource.php",
+          "src/Source/UserSource.php",
+          "src/Source/TermSource.php",
+          "src/Source/OptionSource.php",
+          "src/Source/RowSource.php",
+          "src/Source/RequestSource.php",
+          "src/Internal/AttributeDrivenHydrator.php",
+          "src/Exception/PostNotFoundException.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 13604,
+        "lines": 307,
+        "sha256": "94c69df1690c4743ce03ce13fdec702a2af10f07d6b861dbacf37b5a3c0612f1"
+      }
+    },
+    {
+      "slug": "bd-validation-rule",
+      "name": "bd-validation-rule",
+      "domain": "better-data",
+      "description": "Add a new validation rule to better-data — implement the Rule interface (NOT \"RuleInterface\"; the actual interface in src/Validation/Rule.php is named Rule), live in src/Validation/Rule/, and follow the canonical contract — check(mixed, string, DataObject) returns null on pass or a short error string on fail; rules other than Required treat null as skip so nullable fields don't false- positive. Each rule is also a PHP attribute (TARGET_PARAMETER | TARGET_PROPERTY | IS_REPEATABLE), is final readonly, holds zero business logic outside check(), and surfaces in JSON Schema via RestSchemaBuilder::applyRuleAttribute when relevant. Use when introducing a rule that isn't in src/Validation/Rule/ (Email, Url, Uuid, Min, Max, MinLength, MaxLength, Regex, OneOf, Required, Callback). Triggers on creating a class implementing Rule, adding a new",
+      "path": "better-data/bd-validation-rule",
+      "skill_path": "better-data/bd-validation-rule/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-validation-rule/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-data/bd-validation-rule/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-data/bd-validation-rule/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-data/bd-validation-rule",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-data",
+        "plugin-version-tested": "phase-9",
+        "php-min": "8.3",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://github.com/lonsdale201/better-data"
+        ],
+        "source-refs": [
+          "src/Validation/Rule.php",
+          "src/Validation/Rule/Required.php",
+          "src/Validation/Rule/Email.php",
+          "src/Validation/Rule/Url.php",
+          "src/Validation/Rule/Uuid.php",
+          "src/Validation/Rule/Min.php",
+          "src/Validation/Rule/Max.php",
+          "src/Validation/Rule/MinLength.php",
+          "src/Validation/Rule/MaxLength.php",
+          "src/Validation/Rule/Regex.php",
+          "src/Validation/Rule/OneOf.php",
+          "src/Validation/Rule/Callback.php",
+          "src/Validation/BuiltInValidator.php",
+          "src/Validation/ValidationResult.php",
+          "src/Internal/RestSchemaBuilder.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 14944,
+        "lines": 355,
+        "sha256": "632fbeda407ced70f10f41bf636e81657ea8e96fd71369c3232ed4b62d0e8939"
+      }
+    },
+    {
+      "slug": "br-atomic-idempotency",
+      "name": "br-atomic-idempotency",
+      "domain": "better-route",
+      "description": "Use better-route 0.5.0 AtomicIdempotencyMiddleware for high-side-effect write endpoints where concurrent duplicate requests must not execute twice. Triggers on AtomicIdempotencyMiddleware, WpdbAtomicIdempotencyStore, ArrayAtomicIdempotencyStore, AtomicIdempotencyStoreInterface, idempotency_in_progress, Idempotency-Key for payment/order/subscription/account-like writes, or when reviewing retry-safe REST endpoints.",
+      "path": "better-route/br-atomic-idempotency",
+      "skill_path": "better-route/br-atomic-idempotency/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-atomic-idempotency/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-atomic-idempotency/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-atomic-idempotency/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-atomic-idempotency",
+      "metadata": {},
+      "resources": [
+        {
+          "path": "agents/openai.yaml",
+          "repo_path": "better-route/br-atomic-idempotency/agents/openai.yaml",
+          "type": "resource",
+          "bytes": 219,
+          "sha256": "1c181d10e59abfdec965662b2527b44b29a3ec87a7d6c3472ad7a5d2024bb75d"
+        }
+      ],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 2990,
+        "lines": 64,
+        "sha256": "9912ca7cbaafe6da0249a972ccffce7a8bb979786e76062e76fa0f23790253b1"
+      }
+    },
+    {
+      "slug": "br-audit-enrichment",
+      "name": "br-audit-enrichment",
+      "domain": "better-route",
+      "description": "Enrich better-route 0.5.0 audit events with safe operational metadata. Use when adding AuditEnricherMiddleware, AuditMiddleware context fields, auth user/provider metadata, hashed Idempotency-Key logging, resource/action audit fields, or reviewing sensitive REST write routes that need traceable but redacted audit events.",
+      "path": "better-route/br-audit-enrichment",
+      "skill_path": "better-route/br-audit-enrichment/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-audit-enrichment/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-audit-enrichment/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-audit-enrichment/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-audit-enrichment",
+      "metadata": {},
+      "resources": [
+        {
+          "path": "agents/openai.yaml",
+          "repo_path": "better-route/br-audit-enrichment/agents/openai.yaml",
+          "type": "resource",
+          "bytes": 219,
+          "sha256": "2ea49bf141018a6f871e829b5ced1f07d9d19471f88867a2bff3f636ee0a32f9"
+        }
+      ],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 1951,
+        "lines": 53,
+        "sha256": "12cc63ca394a6ccc6e93ae2b56ea5b20052bad3f122287bc7f7148f90ef58b0c"
+      }
+    },
+    {
+      "slug": "br-auth-middleware",
+      "name": "br-auth-middleware",
+      "domain": "better-route",
+      "description": "Pick and configure the right authentication middleware for a better-route endpoint — JwtAuthMiddleware (Bearer JWT, HS256 via Hs256JwtVerifier), RS256/ES256 JWT via Rs256JwksJwtVerifier + JwtBearerTokenVerifierAdapter, BearerTokenAuthMiddleware (custom bearer tokens with a verifier callback), ApplicationPasswordAuthMiddleware (WP application passwords), CookieNonceAuthMiddleware (browser-based cookie + nonce auth). Critical v0.3.0 JWT defaults — exp claim is REQUIRED (pass requireExpiration: false to disable), WpClaimsUserMapper no longer maps sub by default (re-add it explicitly if your tokens use sub as user ID), expectedIssuer / expectedAudience enable strict iss/aud checks, maxLifetimeSeconds caps token lifetime, maxTokenLength rejects oversized tokens before parsing. Use ->protectedByMiddleware() at the route layer to defer authorization to the middleware pipeline. Use when adding authentication to an endpoint or group. Triggers on JwtAuthMiddleware, BearerTokenAuthMiddleware, ApplicationPasswordAuthMiddleware, CookieNonceAuthMiddleware, Hs256JwtVerifier, Rs256JwksJwtVerifier, JwtBearerTokenVerifierAdapter, WpClaimsUserMapper.",
+      "path": "better-route/br-auth-middleware",
+      "skill_path": "better-route/br-auth-middleware/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-auth-middleware/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-auth-middleware/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-auth-middleware/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-auth-middleware",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.6.0",
+        "php-min": "8.1",
+        "last-updated": "2026-05-02",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents"
+        ],
+        "source-refs": [
+          "src/Middleware/Jwt/Hs256JwtVerifier.php",
+          "src/Middleware/Jwt/Rs256JwksJwtVerifier.php",
+          "src/Middleware/Jwt/HttpJwksProvider.php",
+          "src/Middleware/Jwt/StaticJwksProvider.php",
+          "src/Middleware/Jwt/JwksProviderInterface.php",
+          "src/Middleware/Jwt/JwtAuthMiddleware.php",
+          "src/Middleware/Jwt/JwtVerifierInterface.php",
+          "src/Middleware/Auth/BearerTokenAuthMiddleware.php",
+          "src/Middleware/Auth/BearerTokenVerifierInterface.php",
+          "src/Middleware/Auth/ApplicationPasswordAuthMiddleware.php",
+          "src/Middleware/Auth/CookieNonceAuthMiddleware.php",
+          "src/Middleware/Auth/WpClaimsUserMapper.php",
+          "src/Middleware/Auth/ClaimsUserMapperInterface.php",
+          "src/Middleware/Auth/JwtBearerTokenVerifierAdapter.php",
+          "src/Middleware/Auth/AuthContext.php",
+          "src/Middleware/Auth/AuthIdentity.php",
+          "src/Router/RouteBuilder.php"
+        ]
+      },
+      "resources": [
+        {
+          "path": "agents/openai.yaml",
+          "repo_path": "better-route/br-auth-middleware/agents/openai.yaml",
+          "type": "resource",
+          "bytes": 224,
+          "sha256": "36ef7ab843d39a0b594e51733d5fb831b4fbd95f2ea51552289d78e9cc12f8c2"
+        }
+      ],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 19304,
+        "lines": 392,
+        "sha256": "a7fe193e33b87cc5e70a9fd24755582f374ae778ad4b2653e8fb66d8cee88f65"
+      }
+    },
+    {
+      "slug": "br-cors-public-client",
+      "name": "br-cors-public-client",
+      "domain": "better-route",
+      "description": "Configure better-route 0.5.0 CORS and preflight support for public REST clients. Use when adding CorsMiddleware, CorsPolicy, Router::options(), Authorization or Idempotency-Key cross-origin requests, credentialed browser clients, app clients, OPTIONS routes, or debugging failed REST preflight requests.",
+      "path": "better-route/br-cors-public-client",
+      "skill_path": "better-route/br-cors-public-client/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-cors-public-client/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-cors-public-client/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-cors-public-client/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-cors-public-client",
+      "metadata": {},
+      "resources": [
+        {
+          "path": "agents/openai.yaml",
+          "repo_path": "better-route/br-cors-public-client/agents/openai.yaml",
+          "type": "resource",
+          "bytes": 241,
+          "sha256": "2b5644bef97d5b6d059d2da033a61fae9c5bfc3c32497a28ebf9beb5bf8ad948"
+        }
+      ],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 2347,
+        "lines": 62,
+        "sha256": "a680c737356bf12fcc972b89f6a07ee027900e2d8186f00e1fdb5a7756a259d3"
+      }
+    },
+    {
+      "slug": "br-crypto",
+      "name": "br-crypto",
+      "domain": "better-route",
+      "description": "Use better-route 0.6.0 Crypto and CryptoEncoding helpers for secure random token generation, base64url encoding/decoding, hex tokens, and constant-time comparisons. Triggers on Crypto::token, Crypto::tokenHex, Crypto::equals, Crypto::base64UrlEncode, Crypto::base64UrlDecode, PKCE, nonce, state, CSRF token, HMAC compare, or replacing !== token comparisons. Updated 2026-05-02.",
+      "path": "better-route/br-crypto",
+      "skill_path": "better-route/br-crypto/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-crypto/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-crypto/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-crypto/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-crypto",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.6.0",
+        "php-min": "8.1",
+        "last-updated": "2026-05-02",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents"
+        ],
+        "source-refs": [
+          "src/Support/Crypto.php",
+          "src/Support/CryptoEncoding.php",
+          "src/Middleware/Jwt/Hs256JwtVerifier.php",
+          "tests/SecurityPrimitivesTest.php"
+        ]
+      },
+      "resources": [
+        {
+          "path": "agents/openai.yaml",
+          "repo_path": "better-route/br-crypto/agents/openai.yaml",
+          "type": "resource",
+          "bytes": 219,
+          "sha256": "6879f987ca3414be22d73601ac2158851bbad14a1271d5b7fc249a9743e2b1ad"
+        }
+      ],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 2071,
+        "lines": 54,
+        "sha256": "3017331f0c22c83de663547c9b7accc640045e22df795c611d9482f4c5b17e56"
+      }
+    },
+    {
+      "slug": "br-error-contract",
+      "name": "br-error-contract",
+      "domain": "better-route",
+      "description": "Reference for the standard better-route error envelope — every error response has shape {error: {code, message, requestId, details}}. Throw ApiException(message, status, errorCode, details) inside handlers; better-route's ErrorNormalizer wraps it. Critical v0.3.0 normalization — for status >= 500 from non-ApiException failures, message is normalized to 'Unexpected error.' and details is empty (internal exception class + message NO LONGER leak); for status === 400 from non-ApiException, details.exception still includes the class name (developer aid for misuse). Common error codes — validation_failed (400, fieldErrors), idempotency_key_required (400), invalid_token (401), insufficient permissions (403), not_found (404), idempotency_conflict / hpos_required / customer_exists (409), rate_limited (429), woo_unavailable (503). Use when handlers need to throw structured errors, or consumers need to interpret them. v0.6.0 adds opt-in OAuth RFC6749 error format via,>meta(['error_format' => 'oauth_rfc6749']) and OAuthErrorNormalizer.",
+      "path": "better-route/br-error-contract",
+      "skill_path": "better-route/br-error-contract/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-error-contract/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-error-contract/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-error-contract/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-error-contract",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.6.0",
+        "php-min": "8.1",
+        "last-updated": "2026-05-02",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents"
+        ],
+        "source-refs": [
+          "src/Http/ApiException.php",
+          "src/Http/ConflictException.php",
+          "src/Http/PreconditionFailedException.php",
+          "src/Http/ErrorNormalizer.php",
+          "src/Http/OAuthErrorNormalizer.php",
+          "src/Http/ResponseNormalizer.php",
+          "src/Http/Response.php",
+          "src/Http/RequestContext.php",
+          "src/Resource/Resource.php"
+        ]
+      },
+      "resources": [
+        {
+          "path": "agents/openai.yaml",
+          "repo_path": "better-route/br-error-contract/agents/openai.yaml",
+          "type": "resource",
+          "bytes": 216,
+          "sha256": "3ed3b5657f605ce409d4dc04ada52265b584cc02651b9210763259743622af53"
+        }
+      ],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 18389,
+        "lines": 441,
+        "sha256": "16e4035de3be4461ff604a3a6a1f9e4cdbaa124d5f9fd6a2b013100a07cf6ccc"
+      }
+    },
+    {
+      "slug": "br-etag-cache",
+      "name": "br-etag-cache",
+      "domain": "better-route",
+      "description": "HTTP-level response caching for better-route GET / HEAD endpoints via ETagMiddleware — computes a hash of the response body (sha1 of json_encode by default), emits an ETag response header, and returns 304 Not Modified with no body when the request's If-None-Match header matches. Critical scope rules — only applies to GET and HEAD; POST / PUT / PATCH / DELETE pass through unchanged (verified at src/Middleware/Cache/ETagMiddleware.php:28-30); only applies to 2xx-non-204 responses (verified at line 33-35) — 4xx / 5xx / 204 / 3xx skip ETag. The default body-hash approach is appropriate for small JSON responses; for large or expensive bodies pass an etagResolver callable to compute the hash from a cheap source (e.g. last_modified timestamp + ID). weak: true emits a weak validator (W/\"hash\"). Use when adding HTTP cacheability to read endpoints. Triggers on ETagMiddleware, If-None-Match, 304 Not Modified.",
+      "path": "better-route/br-etag-cache",
+      "skill_path": "better-route/br-etag-cache/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-etag-cache/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-etag-cache/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-etag-cache/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-etag-cache",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.4.0",
+        "php-min": "8.1",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents"
+        ],
+        "source-refs": [
+          "src/Middleware/Cache/ETagMiddleware.php",
+          "src/Middleware/Cache/CachingMiddleware.php",
+          "src/Middleware/Cache/CacheStoreInterface.php",
+          "src/Middleware/Cache/TransientCacheStore.php",
+          "src/Middleware/MiddlewareInterface.php",
+          "src/Http/RequestContext.php",
+          "src/Http/Response.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 12942,
+        "lines": 269,
+        "sha256": "ef268f149cc4a82c5d9e11369b42a52bf50944cf16b00c66f4d3fe13cd006d8e"
+      }
+    },
+    {
+      "slug": "br-hmac-signature",
+      "name": "br-hmac-signature",
+      "domain": "better-route",
+      "description": "Configure better-route 0.6.0 HmacSignatureMiddleware for signed server-to-server REST requests and webhooks. Use when adding X-Signature, X-Timestamp, X-Key-Id, HmacSecretProviderInterface, ArrayHmacSecretProvider, request body HMAC verification, timestamp replay window checks, multi-key rotation, or replacing unsigned public POST endpoints with shared-secret authentication. Updated 2026-05-02.",
+      "path": "better-route/br-hmac-signature",
+      "skill_path": "better-route/br-hmac-signature/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-hmac-signature/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-hmac-signature/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-hmac-signature/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-hmac-signature",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.6.0",
+        "php-min": "8.1",
+        "last-updated": "2026-05-02",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents"
+        ],
+        "source-refs": [
+          "src/Middleware/Auth/HmacSignatureMiddleware.php",
+          "src/Middleware/Auth/HmacSecretProviderInterface.php",
+          "src/Middleware/Auth/ArrayHmacSecretProvider.php",
+          "src/Support/Crypto.php",
+          "tests/SecurityPrimitivesTest.php"
+        ]
+      },
+      "resources": [
+        {
+          "path": "agents/openai.yaml",
+          "repo_path": "better-route/br-hmac-signature/agents/openai.yaml",
+          "type": "resource",
+          "bytes": 228,
+          "sha256": "8e62c6126fa2eacfad85d9578812c92023cf76f14895e7c46ce885611974a4b9"
+        }
+      ],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 2788,
+        "lines": 83,
+        "sha256": "4cc5a029858cda1abda356910c717f95eefff58d42d0d0df729ad21b511696b6"
+      }
+    },
+    {
+      "slug": "br-idempotency",
+      "name": "br-idempotency",
+      "domain": "better-route",
+      "description": "Configure better-route idempotent write behavior. Use IdempotencyMiddleware for replay-cache semantics and use the separate br-atomic-idempotency skill / AtomicIdempotencyMiddleware for side-effectful writes where concurrent duplicate execution must be prevented. Client sends an Idempotency-Key header; the classic middleware caches the first completed response and returns it on retries within the TTL. Store options — ArrayIdempotencyStore (in-memory, tests), TransientIdempotencyStore (WP transients), and WpdbIdempotencyStore (custom DB table, recommended for production). Critical requirement — call WpdbIdempotencyStore::installSchema() once on plugin activation. Cross-database table names (containing .) are rejected by the table-name guard at WpdbIdempotencyStore.php:107. v0.3.0 default key is identity-aware — pass an explicit keyResolver to preserve pre-v0.3 keys. requireKey: true rejects requests without an Idempotency-Key header (400 idempotency_key_required). Use when duplicate-write protection is needed. Triggers on IdempotencyMiddleware, WpdbIdempotencyStore, Idempotency-Key.",
+      "path": "better-route/br-idempotency",
+      "skill_path": "better-route/br-idempotency/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-idempotency/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-idempotency/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-idempotency/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-idempotency",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.5.0",
+        "php-min": "8.1",
+        "last-updated": "2026-05-01",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents"
+        ],
+        "source-refs": [
+          "src/Middleware/Write/IdempotencyMiddleware.php",
+          "src/Middleware/Write/IdempotencyStoreInterface.php",
+          "src/Middleware/Write/ArrayIdempotencyStore.php",
+          "src/Middleware/Write/TransientIdempotencyStore.php",
+          "src/Middleware/Write/WpdbIdempotencyStore.php",
+          "src/Middleware/Write/AtomicIdempotencyMiddleware.php",
+          "src/Middleware/Write/WpdbAtomicIdempotencyStore.php",
+          "src/Http/ApiException.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 16519,
+        "lines": 320,
+        "sha256": "c562fff51d488c11fac72ef6b3eddffd8fb180b2657870e46ff6f66bf20099bd"
+      }
+    },
+    {
+      "slug": "br-install-and-migrate",
+      "name": "br-install-and-migrate",
+      "domain": "better-route",
+      "description": "Install better-route into a WordPress project and migrate to v0.6.0 — composer VCS repository (NOT yet on Packagist), PHP 8.1+ requirement, all route registration inside rest_api_init. Important — v0.4.0 raw Router write methods (POST / PUT / PATCH / DELETE) DENY by default at the WP permission layer; every write route now needs an explicit intent declaration via ->permission(callable), ->protectedByMiddleware($security), or ->publicRoute(). GET is unchanged. Older v0.3.0 breaking changes still apply when jumping from <0.3 — OpenAPI doc defaults to manage_options, custom-table resources are deny-by-default, JWT exp claim required, identity-aware default keys for cache / idempotency / rate-limit. v0.6.0 adds JWKS JWT verification, Crypto helpers, HMAC signatures, trusted-proxy IP/CIDR allowlists, single-use token stores, and opt-in OAuth error format. Use when adding better-route to a project, bumping the constraint to ^0.6.0, or triaging unintended 403s on writes after upgrade. Triggers on composer require better-route, ->permission, ->protectedByMiddleware, ->publicRoute, \"better-route 403 on POST\".",
+      "path": "better-route/br-install-and-migrate",
+      "skill_path": "better-route/br-install-and-migrate/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-install-and-migrate/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-install-and-migrate/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-install-and-migrate/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-install-and-migrate",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.6.0",
+        "php-min": "8.1",
+        "last-updated": "2026-05-02",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents",
+          "https://github.com/Lonsdale201/better-route"
+        ],
+        "source-refs": [
+          "src/Router/RouteBuilder.php",
+          "src/Resource/ResourcePolicy.php",
+          "src/Middleware/Jwt/Hs256JwtVerifier.php",
+          "src/Middleware/Jwt/Rs256JwksJwtVerifier.php",
+          "src/Middleware/Auth/HmacSignatureMiddleware.php",
+          "src/Middleware/Network/IpAllowlistMiddleware.php",
+          "src/Middleware/Write/SingleUseTokenMiddleware.php",
+          "src/Support/Crypto.php",
+          "src/Middleware/Auth/WpClaimsUserMapper.php",
+          "src/OpenApi/OpenApiRouteRegistrar.php",
+          "src/BetterRoute.php",
+          "composer.json"
+        ]
+      },
+      "resources": [
+        {
+          "path": "agents/openai.yaml",
+          "repo_path": "better-route/br-install-and-migrate/agents/openai.yaml",
+          "type": "resource",
+          "bytes": 222,
+          "sha256": "a1d43100a6601cd9075985896f47548dde4e4ac2d5a2c24a9a76a50c6bb2d671"
+        }
+      ],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 14651,
+        "lines": 287,
+        "sha256": "41cf0f57c52c6327460a07e0f0bcfb9a01fd7ed10309ee51e2f61fb1f0c168f8"
+      }
+    },
+    {
+      "slug": "br-jwks-jwt-auth",
+      "name": "br-jwks-jwt-auth",
+      "domain": "better-route",
+      "description": "Configure better-route 0.6.0 RS256/ES256 JWT verification from JWKS. Use when adding Rs256JwksJwtVerifier, JwksProviderInterface, HttpJwksProvider, StaticJwksProvider, JwtBearerTokenVerifierAdapter, strict JOSE kid matching, issuer/audience checks, JWKS transient cache, better_route/jwks_refresh, or OIDC/OAuth bearer token verification. Rejects none and HS* algorithms. Updated 2026-05-02.",
+      "path": "better-route/br-jwks-jwt-auth",
+      "skill_path": "better-route/br-jwks-jwt-auth/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-jwks-jwt-auth/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-jwks-jwt-auth/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-jwks-jwt-auth/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-jwks-jwt-auth",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.6.0",
+        "php-min": "8.1",
+        "last-updated": "2026-05-02",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents"
+        ],
+        "source-refs": [
+          "src/Middleware/Jwt/Rs256JwksJwtVerifier.php",
+          "src/Middleware/Jwt/JwksProviderInterface.php",
+          "src/Middleware/Jwt/HttpJwksProvider.php",
+          "src/Middleware/Jwt/StaticJwksProvider.php",
+          "src/Middleware/Jwt/JwksKeySanitizer.php",
+          "src/Middleware/Jwt/JwtVerifierInterface.php",
+          "src/Middleware/Auth/JwtBearerTokenVerifierAdapter.php",
+          "src/Middleware/Auth/BearerTokenAuthMiddleware.php",
+          "tests/SecurityPrimitivesTest.php"
+        ]
+      },
+      "resources": [
+        {
+          "path": "agents/openai.yaml",
+          "repo_path": "better-route/br-jwks-jwt-auth/agents/openai.yaml",
+          "type": "resource",
+          "bytes": 216,
+          "sha256": "3077b07f9f70a24deb11db7b1819202eed78912348cc649ee70e802afa39d630"
+        }
+      ],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 3699,
+        "lines": 97,
+        "sha256": "e383005f01c36a87192fd02a8d6dbbe63b17a7a1a1c7b5036dc9884864351529"
+      }
+    },
+    {
+      "slug": "br-network-security",
+      "name": "br-network-security",
+      "domain": "better-route",
+      "description": "Use better-route 0.6.0 network security middleware for trusted-proxy client IP resolution and CIDR allowlists. Triggers on TrustedProxyClientIpResolver, ClientIpResolverInterface, CidrMatcher, IpAllowlistMiddleware, CF-Connecting-IP, X-Forwarded-For, REMOTE_ADDR, trusted proxy CIDRs, IP allowlist, webhook IP pinning, or replacing direct forwarded-header reads. Updated 2026-05-02.",
+      "path": "better-route/br-network-security",
+      "skill_path": "better-route/br-network-security/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-network-security/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-network-security/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-network-security/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-network-security",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.6.0",
+        "php-min": "8.1",
+        "last-updated": "2026-05-02",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents"
+        ],
+        "source-refs": [
+          "src/Middleware/Network/TrustedProxyClientIpResolver.php",
+          "src/Middleware/Network/ClientIpResolverInterface.php",
+          "src/Middleware/Network/CidrMatcher.php",
+          "src/Middleware/Network/IpAllowlistMiddleware.php",
+          "src/Http/ClientIpResolver.php",
+          "src/Middleware/RateLimit/RateLimitMiddleware.php",
+          "tests/SecurityPrimitivesTest.php"
+        ]
+      },
+      "resources": [
+        {
+          "path": "agents/openai.yaml",
+          "repo_path": "better-route/br-network-security/agents/openai.yaml",
+          "type": "resource",
+          "bytes": 228,
+          "sha256": "85f2d752dbcbb1face64da60c72434e3ad6bd935cb0ccc0240be6fa7c8de8811"
+        }
+      ],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 3111,
+        "lines": 87,
+        "sha256": "b668e05a258cd70c03a277ee029cb010866e5bc94df2f10895e956fb300fe9e5"
+      }
+    },
+    {
+      "slug": "br-openapi",
+      "name": "br-openapi",
+      "domain": "better-route",
+      "description": "Generate and serve OpenAPI 3.1.0 documentation for a better-route API — collect contracts via $router->contracts(), pass to BetterRoute::openApiExporter()->export($contracts, $options) for the document, OR use OpenApiRouteRegistrar::register() to publish it as a live /openapi.json endpoint. Critical v0.3.0 default — OpenApiRouteRegistrar's permission is current_user_can( 'manage_options'); the doc is admin-only by default. To make it public, pass 'permissionCallback' => static fn (): bool => true. strictSchemas: true throws InvalidArgumentException on unknown $ref components instead of substituting the v0.2.0 forgiving default ({type: object, additionalProperties: true}); strictSchemas: false preserves backwards-compat. Compose with WooCommerce schemas via BetterRoute::wooOpenApiComponents() and DTO schemas via BetterData\\Route\\BetterRouteBridge::openApiComponents(). Use when exporting OpenAPI docs. Triggers on OpenApiExporter, openApiExporter, OpenApiRouteRegistrar, openapi.json.",
+      "path": "better-route/br-openapi",
+      "skill_path": "better-route/br-openapi/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-openapi/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-openapi/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-openapi/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-openapi",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.4.0",
+        "php-min": "8.1",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents"
+        ],
+        "source-refs": [
+          "src/OpenApi/OpenApiExporter.php",
+          "src/OpenApi/OpenApiRouteRegistrar.php",
+          "src/Router/Router.php",
+          "src/Router/RouteBuilder.php",
+          "src/Resource/Resource.php",
+          "src/Integration/Woo/WooOpenApiComponents.php",
+          "src/BetterRoute.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 16010,
+        "lines": 356,
+        "sha256": "f7067c40634eb06c8229944671c38435a4d942203b0f2a46788214e9f4995f05"
+      }
+    },
+    {
+      "slug": "br-owned-resource-guards",
+      "name": "br-owned-resource-guards",
+      "domain": "better-route",
+      "description": "Add better-route 0.5.0 ownership checks for user-owned REST resources. Use when a route or Resource DSL endpoint must ensure the authenticated user owns the order, record, token, subscription, membership, profile object, or other per-user object. Triggers on OwnershipGuardMiddleware, OwnedResourcePolicy, currentUserOwns, ownerResolver, bypassCapability, and customer-owned or user-owned API routes.",
+      "path": "better-route/br-owned-resource-guards",
+      "skill_path": "better-route/br-owned-resource-guards/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-owned-resource-guards/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-owned-resource-guards/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-owned-resource-guards/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-owned-resource-guards",
+      "metadata": {},
+      "resources": [
+        {
+          "path": "agents/openai.yaml",
+          "repo_path": "better-route/br-owned-resource-guards/agents/openai.yaml",
+          "type": "resource",
+          "bytes": 227,
+          "sha256": "5e85815dc5de27635b0698a2939328dc53387b93e95517ac68b613308d984835"
+        }
+      ],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 2485,
+        "lines": 58,
+        "sha256": "1e4cfe33a10db8472d7362f696b95e2b2601e96ddd360de1f7d3474de160e0e8"
+      }
+    },
+    {
+      "slug": "br-rate-limiting",
+      "name": "br-rate-limiting",
+      "domain": "better-route",
+      "description": "Throttle better-route endpoints via RateLimitMiddleware with two backend choices — WpObjectCacheRateLimiter (preferred, needs persistent object cache like Redis or Memcached; throws RuntimeException at construction if wp_cache_* functions are unavailable) and TransientRateLimiter (fallback, uses WP transients; works without object cache but has higher write latency). Critical v0.3.0 default key is identity-aware — {provider}:user:{userId} → {provider}:sub:{subject} → 'guest', so authenticated users get a per-user limit and anonymous traffic keys on 'guest'. Pre-v0.3 default was IP-based; pass an explicit keyResolver to preserve old keys. In 0.6.0 RateLimitMiddleware can use either legacy Http\\ClientIpResolver or new TrustedProxyClientIpResolver / ClientIpResolverInterface with IPv4/IPv6 CIDRs. REMOTE_ADDR must be in trusted proxy CIDRs before any X-Forwarded-For / CF-Connecting-IP header is consulted. Use when adding throttling. Triggers on RateLimitMiddleware, WpObjectCacheRateLimiter, TransientRateLimiter, ClientIpResolver, TrustedProxyClientIpResolver.",
+      "path": "better-route/br-rate-limiting",
+      "skill_path": "better-route/br-rate-limiting/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-rate-limiting/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-rate-limiting/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-rate-limiting/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-rate-limiting",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.6.0",
+        "php-min": "8.1",
+        "last-updated": "2026-05-02",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents"
+        ],
+        "source-refs": [
+          "src/Middleware/RateLimit/RateLimitMiddleware.php",
+          "src/Middleware/RateLimit/RateLimiterInterface.php",
+          "src/Middleware/RateLimit/RateLimitResult.php",
+          "src/Middleware/RateLimit/WpObjectCacheRateLimiter.php",
+          "src/Middleware/RateLimit/TransientRateLimiter.php",
+          "src/Http/ClientIpResolver.php",
+          "src/Middleware/Network/TrustedProxyClientIpResolver.php",
+          "src/Middleware/Network/ClientIpResolverInterface.php",
+          "src/Middleware/Network/CidrMatcher.php",
+          "src/Http/ApiException.php"
+        ]
+      },
+      "resources": [
+        {
+          "path": "agents/openai.yaml",
+          "repo_path": "better-route/br-rate-limiting/agents/openai.yaml",
+          "type": "resource",
+          "bytes": 218,
+          "sha256": "c6238e80ff5a109a8b4216074220ec807dfca210fd873cdff39497003ea5bd34"
+        }
+      ],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 17383,
+        "lines": 357,
+        "sha256": "1ae5ec39331b4f90e0bf4b1f869d8a7d5c1c831d3a24ce51df2ae21bc08dc8d2"
+      }
+    },
+    {
+      "slug": "br-resource-cpt",
+      "name": "br-resource-cpt",
+      "domain": "better-route",
+      "description": "Create CRUD endpoints over a custom post type via better-route's Resource API — Resource::make('books')->sourceCpt( 'book')->fields([...])->register($router) generates list / get / create / update / delete routes automatically. Important — the source-verified visibility method is ->cptVisibleStatuses(['publish', 'draft']) (the agents.md doc lists ->allowedStatuses but the code at src/Resource/Resource.php:235 is named cptVisibleStatuses; same semantics, different name). Other Resource builder methods — restNamespace, fields, filters, sort, policy, writeSchema (alias payloadSchema), fieldPolicy, deleteMode ('force' or 'trash'), defaultPerPage, maxPerPage, maxOffset, uniformEnvelope, cptVisibilityPolicy, filterSchema. Use when generating CRUD over a CPT. Triggers on Resource::make, ->sourceCpt, \"REST CRUD over post type\" with better-route.",
+      "path": "better-route/br-resource-cpt",
+      "skill_path": "better-route/br-resource-cpt/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-resource-cpt/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-resource-cpt/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-resource-cpt/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-resource-cpt",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.4.0",
+        "php-min": "8.1",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents"
+        ],
+        "source-refs": [
+          "src/Resource/Resource.php",
+          "src/Resource/ResourcePolicy.php",
+          "src/Resource/Cpt/WordPressCptRepository.php",
+          "src/Resource/Cpt/CptRepositoryInterface.php",
+          "src/Resource/Cpt/CptListQuery.php",
+          "src/Resource/Cpt/CptListQueryParser.php",
+          "src/Router/Router.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 15083,
+        "lines": 335,
+        "sha256": "d8230d4b303de84890ebd7e1479317b182b1dc6ec5203ec2aa6cb3e7eba06ef5"
+      }
+    },
+    {
+      "slug": "br-resource-policy",
+      "name": "br-resource-policy",
+      "domain": "better-route",
+      "description": "Configure permission policies on a better-route Resource — use a ResourcePolicy preset (publicReadPrivateWrite, adminOnly, capabilities, callbacks) for per-action authorization, or,>fieldPolicy([...]) for per-field write authorization. The four,>policy([), ->fieldPolicy([ in better-route Resources.",
+      "path": "better-route/br-resource-policy",
+      "skill_path": "better-route/br-resource-policy/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-resource-policy/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-resource-policy/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-resource-policy/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-resource-policy",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.4.0",
+        "php-min": "8.1",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents"
+        ],
+        "source-refs": [
+          "src/Resource/ResourcePolicy.php",
+          "src/Resource/Resource.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 14919,
+        "lines": 312,
+        "sha256": "9f7f26aefc7e70b9adecf3c79d58687aaa8deadd39dd6e6e2b2bd7a768e1062a"
+      }
+    },
+    {
+      "slug": "br-resource-table",
+      "name": "br-resource-table",
+      "domain": "better-route",
+      "description": "Create CRUD endpoints over a custom database table via better-route's Resource API — Resource::make('audit')->sourceTable( 'wp_myapp_events')->fields([...])->policy(...)->register($router). Critical v0.3.0 rule — custom-table resources are deny-by-default for ALL actions including list and get (CPT sources still allow reads, but raw tables don't have WP's visibility model). Without an explicit ->policy() declaration the resource returns 403 on every call. fields() is also REQUIRED — throws InvalidArgumentException if empty (CPT sources have implicit fields from post columns; tables do not). Other Resource builder methods carry over from CPT — filters, sort, writeSchema, fieldPolicy, deleteMode, defaultPerPage. Use when generating CRUD over a custom DB table. Triggers on Resource::make + ->sourceTable, \"REST CRUD over custom table\" with better-route, \"$wpdb->prefix . 'myapp_*'\".",
+      "path": "better-route/br-resource-table",
+      "skill_path": "better-route/br-resource-table/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-resource-table/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-resource-table/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-resource-table/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-resource-table",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.4.0",
+        "php-min": "8.1",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents"
+        ],
+        "source-refs": [
+          "src/Resource/Resource.php",
+          "src/Resource/ResourcePolicy.php",
+          "src/Resource/Table/WordPressTableRepository.php",
+          "src/Resource/Table/TableRepositoryInterface.php",
+          "src/Resource/Table/TableListQuery.php",
+          "src/Resource/Table/TableListQueryParser.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 14129,
+        "lines": 298,
+        "sha256": "986bba706b925b7397321aaeff846e61e5586f988dd11b59c6e3390d675354cf"
+      }
+    },
+    {
+      "slug": "br-routes",
+      "name": "br-routes",
+      "domain": "better-route",
+      "description": "Register custom REST routes via better-route's fluent Router — BetterRoute::router('vendor', 'v1') gives a Router with ->get / ->post / ->put / ->patch / ->delete / ->options returning a RouteBuilder for fluent options (->permission, ->protectedByMiddleware, ->publicRoute, ->meta, ->middleware). Critical v0.4.0 rule — POST / PUT / PATCH / DELETE without an explicit permission declaration deny by default at the WP layer (return 403 before the handler runs); GET and OPTIONS are public by default. Use ->permission(callable) for WP capability checks, ->protectedByMiddleware($security) when an auth middleware handles authentication, ->publicRoute() for intentionally public endpoints. Route handlers receive ID from URL route params first (query / body ID is consulted only when URL doesn't supply one). Inbound X-Request-ID is accepted only if it matches ^[A-Za-z0-9._:-]{1,128}$. Use when registering custom (non-WooCommerce) REST routes. Triggers on BetterRoute::router, $router->get/post/put/patch/delete/options, RouteBuilder.",
+      "path": "better-route/br-routes",
+      "skill_path": "better-route/br-routes/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-routes/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-routes/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-routes/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-routes",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.5.0",
+        "php-min": "8.1",
+        "last-updated": "2026-05-01",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents"
+        ],
+        "source-refs": [
+          "src/Router/Router.php",
+          "src/Router/RouteBuilder.php",
+          "src/Router/RouteDefinition.php",
+          "src/Router/RouteMeta.php",
+          "src/Router/WordPressRestDispatcher.php",
+          "src/Router/ArgumentResolver.php",
+          "src/Http/Response.php",
+          "src/Http/RequestContext.php",
+          "src/Http/ApiException.php",
+          "src/BetterRoute.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 15658,
+        "lines": 320,
+        "sha256": "d4dab1c3e0a8e5f85a57cbcb4dcda08647c05c3a12a5c2c6fb59c1ed7795aee9"
+      }
+    },
+    {
+      "slug": "br-single-use-token",
+      "name": "br-single-use-token",
+      "domain": "better-route",
+      "description": "Use better-route 0.6.0 SingleUseTokenMiddleware and stores for auth codes, reset links, magic links, email confirmation tokens, or any token that must be consumed exactly once. Triggers on SingleUseTokenMiddleware, SingleUseTokenStoreInterface, WpdbSingleUseTokenStore, WpCacheSingleUseTokenStore, ArraySingleUseTokenStore, token replay, single-use code, one-time token, or auth-code TOCTOU fixes. Updated 2026-05-02.",
+      "path": "better-route/br-single-use-token",
+      "skill_path": "better-route/br-single-use-token/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-single-use-token/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-single-use-token/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-single-use-token/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-single-use-token",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.6.0",
+        "php-min": "8.1",
+        "last-updated": "2026-05-02",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents"
+        ],
+        "source-refs": [
+          "src/Middleware/Write/SingleUseTokenMiddleware.php",
+          "src/Middleware/Write/SingleUseTokenStoreInterface.php",
+          "src/Middleware/Write/WpdbSingleUseTokenStore.php",
+          "src/Middleware/Write/WpCacheSingleUseTokenStore.php",
+          "src/Middleware/Write/ArraySingleUseTokenStore.php",
+          "tests/SecurityPrimitivesTest.php"
+        ]
+      },
+      "resources": [
+        {
+          "path": "agents/openai.yaml",
+          "repo_path": "better-route/br-single-use-token/agents/openai.yaml",
+          "type": "resource",
+          "bytes": 221,
+          "sha256": "ba042c68e686e6eaae000df5e0e41ff040288e4be86df81c1824b8008f66bb19"
+        }
+      ],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 3184,
+        "lines": 77,
+        "sha256": "2ebbb0af8c4622a055871ac35f0019d215d5ba2affe7d8d84456ce6fa2632571"
+      }
+    },
+    {
+      "slug": "br-woo-routes",
+      "name": "br-woo-routes",
+      "domain": "better-route",
+      "description": "Expose WooCommerce data (orders, products, customers, coupons) via REST using BetterRoute::wooRouteRegistrar()->register( $namespace, $options). Critical v0.3.0 behavior — customer endpoints return ONLY users with the customer role; create / update / delete additionally require WP capabilities create_users / edit_user / delete_user. Meta keys starting with _ (underscore) are NOT writable or returned by default — pass $allowProtected = true on MetaDataHelper calls only when intentional. Order list query patterns — ?status=processing&sort=-date_created&page=1&per_page=50; fields= is comma-separated; sort prefix - = DESC; per_page capped at maxPerPage (default 100); pagination via X-WP-Total / X-WP-TotalPages headers. WooRouteRegistrar options — basePath, requireHpos (default true), defaultPerPage, maxPerPage, deleteMode, actions, permissions, idempotency. Use when exposing WC data over REST. Triggers on BetterRoute::wooRouteRegistrar, MetaDataHelper, /woo/ in better-route.",
+      "path": "better-route/br-woo-routes",
+      "skill_path": "better-route/br-woo-routes/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-woo-routes/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-woo-routes/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-woo-routes/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-woo-routes",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.4.0",
+        "php-min": "8.1",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents"
+        ],
+        "source-refs": [
+          "src/Integration/Woo/WooRouteRegistrar.php",
+          "src/Integration/Woo/WooOrderService.php",
+          "src/Integration/Woo/WooProductService.php",
+          "src/Integration/Woo/WooCustomerService.php",
+          "src/Integration/Woo/WooCouponService.php",
+          "src/Integration/Woo/MetaDataHelper.php",
+          "src/Integration/Woo/HposGuard.php",
+          "src/Integration/Woo/OrderListQueryParser.php",
+          "src/Integration/Woo/ProductListQueryParser.php",
+          "src/Integration/Woo/CustomerListQueryParser.php",
+          "src/Integration/Woo/CouponListQueryParser.php",
+          "src/Integration/Woo/WooOpenApiComponents.php",
+          "src/BetterRoute.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 16579,
+        "lines": 339,
+        "sha256": "97bb3e1cd72522388ea585a4827cad50b7a6bc5d012a42630756809de4ca809b"
+      }
+    },
+    {
+      "slug": "br-write-schema",
+      "name": "br-write-schema",
+      "domain": "better-route",
+      "description": "Validate POST / PUT / PATCH bodies on a better-route Resource via ->writeSchema([...]) (alias ->payloadSchema([...])). Maps each field to a rule array with type / required / nullable / min / max / minLength / maxLength / regex / enum-values / sanitize. Important — the source-verified shape for enum is {type: 'enum', 'values': [...]} (FLAT), NOT {type: 'enum', 'enum': {'values': [...]}} (the agents.md doc nests it). Verified at src/Resource/Resource.php: 1366 — assertValueConstraints reads $rule['values'] directly. Other shape rules — sanitize values are 'text'|'email'|'key'|'url'|callable; type values are int|integer / float|number / bool|boolean / string / date / email / url / enum / array / object / mixed (the integer / number / boolean variants are aliases). Validation failures throw ApiException with code validation_failed and details.fieldErrors. Use when adding payload validation to a Resource. Triggers on,>writeSchema(, ->payloadSchema(, fieldErrors, validation_failed.",
+      "path": "better-route/br-write-schema",
+      "skill_path": "better-route/br-write-schema/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-write-schema/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/better-route/br-write-schema/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/better-route/br-write-schema/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/better-route/br-write-schema",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "better-route",
+        "plugin-version-tested": "0.4.0",
+        "php-min": "8.1",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://lonsdale201.github.io/better-docs/docs/better-route/agents"
+        ],
+        "source-refs": [
+          "src/Resource/Resource.php",
+          "src/Http/ApiException.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 15479,
+        "lines": 308,
+        "sha256": "e043c074d7a320f547cb06a12ca1addf2b8d697f9392bf75c8ba479f0d0908ad"
+      }
+    },
+    {
+      "slug": "fluentcrm-funnel-action",
+      "name": "fluentcrm-funnel-action",
+      "domain": "fluentcrm",
+      "description": "Build a custom FluentCRM funnel action — a sequence step that runs per-contact when an automation reaches it — by extending BaseAction. Covers the three abstract methods (getBlock, getBlockFields, handle), the per-step handle($subscriber, $sequence, $funnelSubscriberId, $funnelMetric) signature, and the canonical skip / failure semantics — handle ONLY overrides status on early-return, because FunnelProcessor::processSequence already marks the sequence 'complete' BEFORE dispatch. Important — the status string canon is 'complete' (NOT 'completed'); both the sequence-subscriber row (via FunnelHelper::changeFunnelSubSequenceStatus) AND the FunnelMetric ($funnelMetric->status + ->save()) need updating on skip. Same lifecycle rule as triggers — register on fluentcrm_loaded priority below 10. Use when building integration actions. Triggers on BaseAction, fluentcrm_funnel_blocks, fluentcrm_funnel_block_fields, fluentcrm_funnel_sequence_handle_, changeFunnelSubSequenceStatus, funnelMetric, getBlockFields.",
+      "path": "fluentcrm/fluentcrm-funnel-action",
+      "skill_path": "fluentcrm/fluentcrm-funnel-action/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/fluentcrm/fluentcrm-funnel-action/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/fluentcrm/fluentcrm-funnel-action/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/fluentcrm/fluentcrm-funnel-action/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/fluentcrm/fluentcrm-funnel-action",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "fluent-crm",
+        "plugin-version-tested": "2.9.87",
+        "api-stable-since": "2.7",
+        "php-min": "7.4",
+        "last-updated": "2026-05-10",
+        "docs": [
+          "https://developers.fluentcrm.com/funnel-builder/custom-action/"
+        ],
+        "source-refs": [
+          "app/Services/Funnel/BaseAction.php",
+          "app/Services/Funnel/FunnelProcessor.php",
+          "app/Services/Funnel/FunnelHelper.php",
+          "app/Models/FunnelMetric.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 23616,
+        "lines": 298,
+        "sha256": "d4eb281a0f39f009d6d7cea64f204f8467dee31385b419c4ef35143b08b377ba"
+      }
+    },
+    {
+      "slug": "fluentcrm-funnel-benchmark",
+      "name": "fluentcrm-funnel-benchmark",
+      "domain": "fluentcrm",
+      "description": "Build a custom FluentCRM funnel benchmark — a goal/wait point inside a sequence that pauses execution until a matching event occurs (tag applied, list joined, course completed, custom event). Extends BaseBenchMark. Covers the three abstract methods (getBlock, getBlockFields, handle), Optional vs Essential semantics, the can_enter direct-entry toggle, the assertCurrentGoalState filter, and FunnelProcessor::startFunnelFromSequencePoint as the canonical resume entry — NOT startFunnelSequence (that starts a new run). Important — same lifecycle rule as triggers (register on fluentcrm_loaded priority below 10); benchmarks share the action listener with triggers via FunnelHandler::mapTriggers, so fluentcrm_funnel_arg_num_{name} timing applies. Use when a funnel needs to wait for a contact-state change. Triggers on BaseBenchMark, fluentcrm_funnel_benchmark_start_, assertCurrentGoalState, startFunnelFromSequencePoint, benchmarkTypeField, canEnterField.",
+      "path": "fluentcrm/fluentcrm-funnel-benchmark",
+      "skill_path": "fluentcrm/fluentcrm-funnel-benchmark/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/fluentcrm/fluentcrm-funnel-benchmark/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/fluentcrm/fluentcrm-funnel-benchmark/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/fluentcrm/fluentcrm-funnel-benchmark/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/fluentcrm/fluentcrm-funnel-benchmark",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "fluent-crm",
+        "plugin-version-tested": "2.9.87",
+        "api-stable-since": "2.6",
+        "php-min": "7.4",
+        "last-updated": "2026-05-09",
+        "docs": [
+          "https://developers.fluentcrm.com/funnel-builder/custom-benchmark/"
+        ],
+        "source-refs": [
+          "app/Services/Funnel/BaseBenchMark.php",
+          "app/Services/Funnel/FunnelProcessor.php",
+          "app/Services/Funnel/Benchmarks/TagAppliedBenchmark.php",
+          "app/Hooks/Handlers/FunnelHandler.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 20023,
+        "lines": 277,
+        "sha256": "8ad916112598740a080163ad835d104e13b1245fcce32f25b006de395cae473e"
+      }
+    },
+    {
+      "slug": "fluentcrm-funnel-trigger",
+      "name": "fluentcrm-funnel-trigger",
+      "domain": "fluentcrm",
+      "description": "Build a custom FluentCRM funnel trigger by extending BaseTrigger. Covers the four abstract methods (getTrigger, getFunnelSettingsDefaults, getSettingsFields, handle), the auto-injected __force_run_actions field, the canonical isProcessable / run_multiple / ifAlreadyInFunnel guard, the fluentcrm_funnel_will_process_{name} filter parity, source_trigger_name / source_ref_id metadata for FunnelProcessor::startFunnelSequence. Important — register on fluentcrm_loaded priority below 10, NEVER on fluent_crm/after_init. FunnelHandler::handle runs on fluentcrm_addons_loaded and locks in actionArgNum=1 if fluentcrm_funnel_arg_num_{name} is absent — multi-arg hooks like lw_lms_after_grant silently drop args past the first. Use when scaffolding a CRM integration. Triggers on BaseTrigger, fluentcrm_funnel_triggers, fluentcrm_funnel_start_, fluentcrm_funnel_arg_num_, FunnelProcessor, FunnelHelper, fluentcrm_funnel_settings, source_trigger_name.",
+      "path": "fluentcrm/fluentcrm-funnel-trigger",
+      "skill_path": "fluentcrm/fluentcrm-funnel-trigger/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/fluentcrm/fluentcrm-funnel-trigger/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/fluentcrm/fluentcrm-funnel-trigger/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/fluentcrm/fluentcrm-funnel-trigger/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/fluentcrm/fluentcrm-funnel-trigger",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "fluent-crm",
+        "plugin-version-tested": "2.9.87",
+        "api-stable-since": "2.7",
+        "php-min": "7.4",
+        "last-updated": "2026-05-10",
+        "docs": [
+          "https://developers.fluentcrm.com/funnel-builder/custom-trigger/"
+        ],
+        "source-refs": [
+          "app/Services/Funnel/BaseTrigger.php",
+          "app/Services/Funnel/FunnelProcessor.php",
+          "app/Services/Funnel/FunnelHelper.php",
+          "app/Hooks/Handlers/FunnelHandler.php",
+          "app/Hooks/actions.php",
+          "boot/app.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 26440,
+        "lines": 403,
+        "sha256": "4a46dc3ce77eb5541ef62f2ae297812ee93f2625026a7af137410225ce2fd049"
+      }
+    },
+    {
+      "slug": "fluentcrm-overview",
+      "name": "fluentcrm-overview",
+      "domain": "fluentcrm",
+      "description": "Orient skill for FluentCRM extension development. Covers the Free / Pro split (FluentCRM = funnel chassis; FluentCampaign Pro = integrations + advanced actions / benchmarks), plugin paths and constants, the bootstrap order (fluentcrm_loaded → fluentcrm_addons_loaded → fluent_crm/after_init), the model layer (Subscriber, Funnel, FunnelSequence, FunnelSubscriber, FunnelMetric), the global helpers (FluentCrmApi, fluentCrmDb, FunnelHelper), the contact lifecycle hooks (fluent_crm/contact_created, _updated, _email_changed, _custom_data_updated), the smart-code extension filter (fluent_crm/extended_smart_codes), and a decision matrix for picking the right extension contract. Use when scaffolding a new FluentCRM integration, choosing which contract to extend, or asking where things live. Triggers on FluentCrmApi, fluentCrmDb, FunnelHelper, fluent_crm/contact_, fluent_crm/extended_smart_codes, FLUENTCRM, FLUENTCAMPAIGN.",
+      "path": "fluentcrm/fluentcrm-overview",
+      "skill_path": "fluentcrm/fluentcrm-overview/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/fluentcrm/fluentcrm-overview/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/fluentcrm/fluentcrm-overview/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/fluentcrm/fluentcrm-overview/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/fluentcrm/fluentcrm-overview",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "fluent-crm",
+        "plugin-version-tested": "2.9.87",
+        "api-stable-since": "2.7",
+        "php-min": "7.4",
+        "last-updated": "2026-05-10",
+        "docs": [
+          "https://developers.fluentcrm.com/"
+        ],
+        "source-refs": [
+          "fluent-crm.php",
+          "boot/app.php",
+          "app/Functions/helpers.php",
+          "app/Models/Subscriber.php",
+          "app/Services/Helper.php",
+          "app/Api/Classes/Extender.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 22114,
+        "lines": 360,
+        "sha256": "a3788aee4e4bcc89a115ddf5eca01969e114b7c657a48c997a3a3d50082315d9"
+      }
+    },
+    {
+      "slug": "fluentcrm-rest-options",
+      "name": "fluentcrm-rest-options",
+      "domain": "fluentcrm",
+      "description": "Register a custom AJAX option list for FluentCRM trigger / action / benchmark editor pickers. Pairs `'type' => 'rest_selector', 'option_key' => '<key>'` in a settings field with a server-side `add_filter('fluentcrm_ajax_options_<key>', $callback, 10, 3)` callback. Filter signature is ($options, $search, $includedIds) — return an array of {id, title} pairs. The fallback apply_filters call lives in OptionsController::getAjaxOptions which the editor's REST hits as the user types or opens the picker. Important — pre-selected ids must always be returned (regardless of $search) or the editor renders saved values as raw IDs instead of human labels. Use when scaffolding any FluentCRM trigger / action / benchmark with a multi-select-like field. Triggers on fluentcrm_ajax_options_, rest_selector, option_key, getAjaxOptions, OptionsController.",
+      "path": "fluentcrm/fluentcrm-rest-options",
+      "skill_path": "fluentcrm/fluentcrm-rest-options/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/fluentcrm/fluentcrm-rest-options/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/fluentcrm/fluentcrm-rest-options/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/fluentcrm/fluentcrm-rest-options/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/fluentcrm/fluentcrm-rest-options",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "fluent-crm",
+        "plugin-version-tested": "2.9.87",
+        "api-stable-since": "2.5.9",
+        "php-min": "7.4",
+        "last-updated": "2026-05-09",
+        "docs": [
+          "https://developers.fluentcrm.com/funnel-builder/custom-trigger/"
+        ],
+        "source-refs": [
+          "app/Http/Controllers/OptionsController.php",
+          "app/Services/ExternalIntegrations/FluentCart/FluentCart.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 12549,
+        "lines": 203,
+        "sha256": "b1bc3e1763a82bfdd0920bb0f1b0f4d7850c4d3401af2b0f13914f8694a8d7fe"
+      }
+    },
+    {
+      "slug": "je-dynamic-visibility-condition",
+      "name": "je-dynamic-visibility-condition",
+      "domain": "jet-engine",
+      "description": "Register a custom Dynamic Visibility condition for JetEngine — extend \\Jet_Engine\\Modules\\Dynamic_Visibility\\Conditions\\ Base, hook jet-engine/modules/dynamic-visibility/conditions/register, call $manager->register_condition( new MyCondition() ). The 3 abstract methods are get_id() / get_name() / check( $args = [] ); override get_group() to assign a UI group, is_for_fields() / need_value_detect() / need_type_detect() to control where the condition appears, get_custom_controls() to add per-condition UI controls. The check() $args includes type ('show' or 'hide'), field / field_raw, value, data_type ('chars' / 'numeric' / 'datetime' / 'date' / 'list'), and context ('default' or 'current_listing'). Important — $args['type'] is the user's show/hide intent; condition must invert its boolean accordingly. Use get_current_value() helper for context-aware meta resolution (handles WP_Post, WP_User, WP_Term, WP_Comment, listing macros). Use when scaffolding a JetEngine companion plugin's visibility conditions.",
+      "path": "jet-engine/je-dynamic-visibility-condition",
+      "skill_path": "jet-engine/je-dynamic-visibility-condition/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jet-engine/je-dynamic-visibility-condition/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jet-engine/je-dynamic-visibility-condition/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/jet-engine/je-dynamic-visibility-condition/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/jet-engine/je-dynamic-visibility-condition",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "jet-engine",
+        "plugin-version-tested": "3.8.8.2",
+        "php-min": "7.4",
+        "last-updated": "2026-05-01",
+        "docs": [
+          "https://crocoblock.com/knowledge-base/plugins/jetengine/",
+          "https://github.com/Crocoblock/developer-documentation/tree/main/01-jet-engine"
+        ],
+        "source-refs": [
+          "wp-content/plugins/jet-engine/includes/modules/dynamic-visibility/inc/conditions/base.php",
+          "wp-content/plugins/jet-engine/includes/modules/dynamic-visibility/inc/conditions/equal.php",
+          "wp-content/plugins/jet-engine/includes/modules/dynamic-visibility/inc/conditions/week-days.php",
+          "wp-content/plugins/jet-engine/includes/modules/dynamic-visibility/inc/conditions-checker.php",
+          "wp-content/plugins/jet-engine/includes/modules/dynamic-visibility/inc/module.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 27027,
+        "lines": 537,
+        "sha256": "e05273461c7345e649f94c19e81c386438b11a64204702155f70dcd00e218f69"
+      }
+    },
+    {
+      "slug": "je-listings-callback",
+      "name": "je-listings-callback",
+      "domain": "jet-engine",
+      "description": "Register a custom Listings callback for JetEngine — the per-field transform fired when a Dynamic Field widget renders meta values (Format date, Format number, Get post title, Convert units, …). Two registration paths are supported. Legacy 3-filter via jet-engine/listings/allowed-callbacks (label), jet-engine/listings/allowed-callbacks-args (control schema), and jet-engine/listing/dynamic-field/callback-args (positional args at runtime). Modern single-call $manager->register_callback($name, $label, $args) hooked on jet-engine/callbacks/register fires the three filters internally for you. Critical contract — the callback identifier you register MUST be a real PHP callable string (a global function name OR `Fully\\\\Qualified\\\\Class::method`). Bare static method names like `'unit_converter'` fail JE's is_callable() gate at apply_callback() and the rendered field silently becomes empty. Use when scaffolding a JetEngine companion plugin's listing-field transform, when seeing \"callback applied but value disappears\" bugs, or when extending the field-args UI.",
+      "path": "jet-engine/je-listings-callback",
+      "skill_path": "jet-engine/je-listings-callback/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jet-engine/je-listings-callback/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jet-engine/je-listings-callback/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/jet-engine/je-listings-callback/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/jet-engine/je-listings-callback",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "jet-engine",
+        "plugin-version-tested": "3.8.8.2",
+        "php-min": "7.4",
+        "last-updated": "2026-05-01",
+        "docs": [
+          "https://crocoblock.com/knowledge-base/plugins/jetengine/",
+          "https://github.com/Crocoblock/developer-documentation/tree/main/01-jet-engine"
+        ],
+        "source-refs": [
+          "wp-content/plugins/jet-engine/includes/components/listings/callbacks.php",
+          "wp-content/plugins/jet-engine/includes/components/listings/render/dynamic-field.php",
+          "wp-content/plugins/jet-engine/includes/core/functions.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 20000,
+        "lines": 335,
+        "sha256": "f14e75b3198e4f3a0fac401dd14e7671ee8846d7644dbb6fd1f5d41c08ced0e5"
+      }
+    },
+    {
+      "slug": "je-query-builder-custom-type",
+      "name": "je-query-builder-custom-type",
+      "domain": "jet-engine",
+      "description": "Register a custom Query type for JetEngine's Query Builder — extend \\Jet_Engine\\Query_Builder\\Queries\\Base_Query for the runtime query class, extend \\Jet_Engine\\Query_Builder\\Query_Editor\\Base_Query for the editor component, then hook BOTH register actions — jet-engine/query-builder/queries/register (factory) for the runtime, jet-engine/query-builder/query-editor/register for the editor UI. Five abstract methods on Base_Query — _get_items(), get_items_total_count(), get_items_page_count(), get_items_pages_count(), get_current_items_page(). Built-in cache via get_cached_data() / update_query_cache(). Custom queries participate in JE 3.8+ MCP tool exposure and the frontend query inspector automatically. Use when scaffolding a custom query type (HPOS WC orders, third-party API source, custom DB table) for JetEngine listings, dynamic widgets, or REST API endpoints.",
+      "path": "jet-engine/je-query-builder-custom-type",
+      "skill_path": "jet-engine/je-query-builder-custom-type/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jet-engine/je-query-builder-custom-type/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jet-engine/je-query-builder-custom-type/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/jet-engine/je-query-builder-custom-type/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/jet-engine/je-query-builder-custom-type",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "jet-engine",
+        "plugin-version-tested": "3.8.8.2",
+        "php-min": "7.4",
+        "last-updated": "2026-05-01",
+        "docs": [
+          "https://crocoblock.com/knowledge-base/plugins/jetengine/",
+          "https://github.com/Crocoblock/developer-documentation/tree/main/01-jet-engine"
+        ],
+        "source-refs": [
+          "wp-content/plugins/jet-engine/includes/components/query-builder/queries/base.php",
+          "wp-content/plugins/jet-engine/includes/components/query-builder/queries/posts.php",
+          "wp-content/plugins/jet-engine/includes/components/query-builder/query-factory.php",
+          "wp-content/plugins/jet-engine/includes/components/query-builder/query-editor.php",
+          "wp-content/plugins/jet-engine/includes/components/query-builder/editor/base.php",
+          "wp-content/plugins/jet-engine/includes/components/query-builder/manager.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 40394,
+        "lines": 739,
+        "sha256": "bd2208c42b444aa12eb739d530ee79d3cb83ed85e6e21125393cd44cbcfca0a3"
+      }
+    },
+    {
+      "slug": "jfb-action-events",
+      "name": "jfb-action-events",
+      "domain": "jetformbuilder",
+      "description": "Configures the JetFormBuilder action events system — the named events (DEFAULT.PROCESS, DEFAULT.REQUIRED, GATEWAY.SUCCESS, GATEWAY.FAILED, BAD.REQUEST, ON.DYNAMIC_STATE, never) that decide WHEN a Form Action runs. Covers declaring supported / unsupported / required events on a custom action, the validation precedence inside Base_Event::is_valid_action(), the multi-event subscription model the action editor exposes, and how to register a brand-new event type via the 'jet-form-builder/event-types' filter using Base_Event, Base_Action_Event, or Base_Gateway_Event. Use when an action needs to run only on payment callbacks, only on validation failure, only on a specific conditional state, after another action's hidden flow, or when the plugin needs to define its own event class (e.g. for inbound webhooks). Triggers on mentions of \"JFB events\", \"action events\", \"GATEWAY.SUCCESS\", \"DEFAULT.PROCESS\", \"supported_events\", \"unsupported_events\", \"get_required_events\", \"Base_Event\", \"Base_Gateway_Event\", \"jet-form-builder/event-types\", \"before-trigger-event\", \"add_hidden\".",
+      "path": "jetformbuilder/jfb-action-events",
+      "skill_path": "jetformbuilder/jfb-action-events/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jetformbuilder/jfb-action-events/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jetformbuilder/jfb-action-events/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/jetformbuilder/jfb-action-events/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/jetformbuilder/jfb-action-events",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "jetformbuilder",
+        "plugin-version-tested": "3.5.6",
+        "api-stable-since": "3.0",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://github.com/Crocoblock/developer-documentation/tree/main/03-jet-form-builder"
+        ],
+        "source-refs": [
+          "includes/actions/events/base-event.php",
+          "includes/actions/events/base-action-event.php",
+          "includes/actions/events/base-gateway-event.php",
+          "includes/actions/events-list.php",
+          "includes/actions/events-manager.php",
+          "includes/actions/types/base.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 30759,
+        "lines": 431,
+        "sha256": "7f607ee52ba222cbe4f63d6856768e69c65e43ef70f7f6495ca7276ca34367a1"
+      }
+    },
+    {
+      "slug": "jfb-action-external-api",
+      "name": "jfb-action-external-api",
+      "domain": "jetformbuilder",
+      "description": "How to read submitted JetFormBuilder form data from a custom action, transform it (including %macro% replacement of admin-typed templates), call an external HTTP API, write the response back into the form context for downstream actions to use, and dispatch JFB events based on the API outcome. Use when building a custom action that integrates with a third-party service (LLM call, webhook, CRM, payment processor, geolocation lookup) and needs the action to behave as a node in a data-flow graph rather than a one-shot leaf. Triggers on mentions of \"jet_fb_context\", \"update_request\", \"has_field\", \"get_value\", \"wp_remote_post\" with form data, \"macro replacement\", or \"API call from action\".",
+      "path": "jetformbuilder/jfb-action-external-api",
+      "skill_path": "jetformbuilder/jfb-action-external-api/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jetformbuilder/jfb-action-external-api/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jetformbuilder/jfb-action-external-api/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/jetformbuilder/jfb-action-external-api/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/jetformbuilder/jfb-action-external-api",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "jetformbuilder",
+        "plugin-version-tested": "3.5.6",
+        "api-stable-since": "3.0",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://github.com/Crocoblock/developer-documentation/tree/main/03-jet-form-builder",
+          "https://developer.wordpress.org/reference/functions/wp_remote_post/"
+        ],
+        "source-refs": [
+          "includes/context/context.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 23721,
+        "lines": 427,
+        "sha256": "cb4f02a48b960bbebc412a7f1146a7f43144323412e5af2f82803efddfd65df6"
+      }
+    },
+    {
+      "slug": "jfb-action-item-decorator",
+      "name": "jfb-action-item-decorator",
+      "domain": "jetformbuilder",
+      "description": "Wraps every action item in the JetFormBuilder action editor with custom UI via the 'jet.fb.action.item' wp.hooks filter — the wrapper renders on top of (or alongside) the original action editor for each action and can read/write that action's settings and events array. Use to add quick toggles or panels to every action without modifying each action's own editor — e.g. a TRUE/FALSE/Always button group that drives which custom event the action responds to, a \"run once per session\" toggle, an inline label override, any visual shortcut over the action's persisted state. Triggers on mentions of \"jet.fb.action.item\", \"useLoopedAction\", \"useActionsEdit\", \"useActions\", \"ActionItemWrapper\", \"ActionItemBody\", \"decorate every action\", \"per-action toggle\", or \"visual control over action events\".",
+      "path": "jetformbuilder/jfb-action-item-decorator",
+      "skill_path": "jetformbuilder/jfb-action-item-decorator/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jetformbuilder/jfb-action-item-decorator/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jetformbuilder/jfb-action-item-decorator/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/jetformbuilder/jfb-action-item-decorator/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/jetformbuilder/jfb-action-item-decorator",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "jetformbuilder",
+        "plugin-version-tested": "3.5.6",
+        "api-stable-since": "3.0",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://github.com/Crocoblock/developer-documentation/tree/main/03-jet-form-builder",
+          "https://developer.wordpress.org/block-editor/reference-guides/packages/packages-hooks/"
+        ],
+        "source-refs": [
+          "assets/build/editor/form.builder.js"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 23517,
+        "lines": 417,
+        "sha256": "06e9a486ab4e6aa36a26cf38a7606669bd53f131d130741b0e82d8246d3cd3a3"
+      }
+    },
+    {
+      "slug": "jfb-action-messages",
+      "name": "jfb-action-messages",
+      "domain": "jetformbuilder",
+      "description": "Surfaces user-facing custom messages from a JetFormBuilder custom Form Action — both the idiomatic path (register message types via 'jet-form-builder/form-messages/register' so they appear in the form's Messages panel and can be overridden globally per form) and the action-local path (custom message fields inside the action editor, dispatched via Action_Exception for errors or via context + 'jet-form-builder/form-handler/after-send' + Messages_Manager::dynamic_success() for success messages). Use when a custom JFB action needs configurable messages for cases like \"already subscribed\", \"duplicate row skipped\", \"API rate limited\", or per-action success copy. Triggers on mentions of \"JFB messages\", \"Action_Exception\", \"Base_Action_Messages\", \"jet-form-builder/form-messages/register\", \"_jf_messages\", \"dynamic_success\", \"add_context_once\" with a message, \"after-send\" hook, or \"custom action message\".",
+      "path": "jetformbuilder/jfb-action-messages",
+      "skill_path": "jetformbuilder/jfb-action-messages/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jetformbuilder/jfb-action-messages/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jetformbuilder/jfb-action-messages/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/jetformbuilder/jfb-action-messages/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/jetformbuilder/jfb-action-messages",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "jetformbuilder",
+        "plugin-version-tested": "3.5.6",
+        "api-stable-since": "3.0",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://github.com/Crocoblock/developer-documentation/tree/main/03-jet-form-builder"
+        ],
+        "source-refs": [
+          "includes/form-messages/manager.php",
+          "includes/form-messages/action-messages-manager.php",
+          "includes/form-messages/actions/base-action-messages.php",
+          "modules/post-type/meta/messages-meta.php",
+          "modules/actions-v2/register-user/messages/register-user-messages.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 19455,
+        "lines": 337,
+        "sha256": "81f5498604a87b1c4919ba0b1e71fded9fb90e4f4b42bb647deb77803857ab79"
+      }
+    },
+    {
+      "slug": "jfb-form-action",
+      "name": "jfb-form-action",
+      "domain": "jetformbuilder",
+      "description": "Registers a custom JetFormBuilder Form Action — a server-side handler that runs after submit (send to API, subscribe to CRM, write to a sheet, etc.). Covers extending Base action class, declaring settings via action_attributes(), implementing do_action() with Action_Exception error reporting, building the action-editor React panel via window.JetFBActions.addAction(), the two field-mapping patterns (dynamic \"Add row\" like Google Sheets vs fixed-key pattern like Fluent CRM with predefined target fields), looking up the form's current fields via the useFields() hook, multi-select with FormLabeledTokenField, plus the category/docHref convention. Use when scaffolding a JFB integration plugin (Mailchimp, Slack, custom API, payment processor, CRM subscribe). Triggers on mentions of \"JFB action\", \"jet-form-builder/actions/register\", \"Base_Action\", \"JetFBActions.addAction\", \"Action_Exception\", \"field map\", or \"fields_map\".",
+      "path": "jetformbuilder/jfb-form-action",
+      "skill_path": "jetformbuilder/jfb-form-action/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jetformbuilder/jfb-form-action/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jetformbuilder/jfb-form-action/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/jetformbuilder/jfb-form-action/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/jetformbuilder/jfb-form-action",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "jetformbuilder",
+        "plugin-version-tested": "3.5.6",
+        "api-stable-since": "3.0",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://github.com/Crocoblock/developer-documentation/tree/main/03-jet-form-builder",
+          "https://developer.wordpress.org/block-editor/reference-guides/components/"
+        ],
+        "source-refs": [
+          "includes/actions/types/base.php",
+          "includes/actions/manager.php",
+          "includes/actions/action-handler.php",
+          "modules/actions-v2/send-email/send-email-action.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 33708,
+        "lines": 607,
+        "sha256": "1d1a0ae206c9519b1906b0061e1109300f73a0f221beaef7ad06acb31e751221"
+      }
+    },
+    {
+      "slug": "jfb-form-sidebar-panel",
+      "name": "jfb-form-sidebar-panel",
+      "domain": "jetformbuilder",
+      "description": "Adds a per-form settings panel to the JetFormBuilder Gutenberg form editor sidebar — registers REST-exposed post meta on the form CPT, enqueues a block-editor JS bundle, and registers a panel via the JFB-specific 'jet.fb.register.plugins' filter using @wordpress/components (TextControl, SelectControl, ToggleControl) and JFB's useMetaState hook for two-way binding to post meta. Use when a companion plugin needs settings that vary per form (e.g. upload folder, file size limit, integration target) instead of (or in addition to) site-wide defaults from the global Settings page. Triggers on mentions of \"JFB form sidebar\", \"JFB form settings panel\", \"form-level settings\", \"useMetaState\", \"jet.fb.register.plugins\", \"jet-form-builder/editor-assets/before\", or scaffolding a JFB companion plugin that needs per-form config.",
+      "path": "jetformbuilder/jfb-form-sidebar-panel",
+      "skill_path": "jetformbuilder/jfb-form-sidebar-panel/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jetformbuilder/jfb-form-sidebar-panel/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jetformbuilder/jfb-form-sidebar-panel/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/jetformbuilder/jfb-form-sidebar-panel/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/jetformbuilder/jfb-form-sidebar-panel",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "jetformbuilder",
+        "plugin-version-tested": "3.5.6",
+        "api-stable-since": "3.0",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://github.com/Crocoblock/developer-documentation/tree/main/03-jet-form-builder",
+          "https://developer.wordpress.org/block-editor/reference-guides/components/",
+          "https://developer.wordpress.org/reference/functions/register_post_meta/"
+        ],
+        "source-refs": [
+          "modules/post-type/module.php",
+          "modules/post-type/meta/base-meta-type.php",
+          "includes/admin/editor.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 20669,
+        "lines": 378,
+        "sha256": "d3517e90235cd49399ba196bcd1dceba7395f59e143790b57fee63f014657d90"
+      }
+    },
+    {
+      "slug": "jfb-settings-tab",
+      "name": "jfb-settings-tab",
+      "domain": "jetformbuilder",
+      "description": "Registers a custom settings tab in the JetFormBuilder admin Settings page using the official JFB API — PHP-side Base_Handler subclass for persistence, JS-side wp.hooks filter for the Vue tab component, native cx-vui field components for the UI. Use when a plugin needs its own configuration tab inside JFB Settings (API credentials, defaults, debug flags, third-party integrations) and the developer must NOT roll their own admin page. Triggers on mentions of \"JetFormBuilder settings tab\", \"JFB settings page\", \"Base_Handler\", \"register-tabs-handlers\", \"jet.fb.register.settings-page.tabs\", \"cx-vui-input\", or when a JFB-companion plugin is being scaffolded.",
+      "path": "jetformbuilder/jfb-settings-tab",
+      "skill_path": "jetformbuilder/jfb-settings-tab/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jetformbuilder/jfb-settings-tab/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/jetformbuilder/jfb-settings-tab/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/jetformbuilder/jfb-settings-tab/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/jetformbuilder/jfb-settings-tab",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "jetformbuilder",
+        "plugin-version-tested": "3.5.6",
+        "api-stable-since": "3.0",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://github.com/Crocoblock/developer-documentation/tree/main/03-jet-form-builder"
+        ],
+        "source-refs": [
+          "includes/admin/tabs-handlers/base-handler.php",
+          "includes/admin/tabs-handlers/tab-handler-manager.php",
+          "includes/admin/tabs-handlers/options-handler.php",
+          "includes/admin/pages/pages-manager.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 17638,
+        "lines": 351,
+        "sha256": "feea1ce3c78fd587f2f0d9b1c835ee0e7f88578c63e4fd2c8d989eb17af48b90"
+      }
+    },
+    {
+      "slug": "lw-lms-abilities",
+      "name": "lw-lms-abilities",
+      "domain": "lw-plugins",
+      "description": "Consumer and reviewer reference for LW LMS Abilities API registrations in lw-lms v1.3.0. Use when calling or auditing `lw-lms/list-courses`, `lw-lms/get-course`, `lw-lms/get-progress`, `lw-lms/set-progress`, `lw-lms/get-options`, `/wp-json/wp-abilities/v1/abilities/lw-lms/.../run`, Site Manager bridge integration, standalone WP 6.9+ Abilities API fallback, ability `input_schema` / `output_schema`, or AI-agent access to LMS course/progress data.",
+      "path": "lw-plugins/lw-lms-abilities",
+      "skill_path": "lw-plugins/lw-lms-abilities/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/lw-plugins/lw-lms-abilities/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/lw-plugins/lw-lms-abilities/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/lw-plugins/lw-lms-abilities/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/lw-plugins/lw-lms-abilities",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "lw-lms",
+        "plugin-version-tested": "1.3.0",
+        "php-min": "8.1",
+        "last-updated": "2026-05-21",
+        "docs": [
+          "https://github.com/lwplugins/lw-lms",
+          "https://developer.wordpress.org/apis/abilities-api/"
+        ],
+        "source-refs": [
+          "wp-content/plugins/lw-lms/includes/SiteManager/Integration.php",
+          "wp-content/plugins/lw-lms/includes/SiteManager/Abilities/CourseAbilities.php",
+          "wp-content/plugins/lw-lms/includes/SiteManager/Abilities/ProgressAbilities.php",
+          "wp-content/plugins/lw-lms/includes/SiteManager/Abilities/OptionsAbilities.php",
+          "wp-content/plugins/lw-lms/includes/SiteManager/Abilities/AbilityPermissions.php",
+          "wp-content/plugins/lw-lms/includes/SiteManager/Abilities/AbilityMeta.php",
+          "wp-content/plugins/lw-lms/includes/SiteManager/Schema/OutputSchemas.php",
+          "wp-content/plugins/lw-lms/includes/SiteManager/Service/",
+          "wp-content/plugins/lw-lms/docs/site-manager-abilities.md"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 7074,
+        "lines": 136,
+        "sha256": "75c5cf0097562cacc30666ceed178c1e4af714c01f2ee361783a1439c8faed42"
+      }
+    },
+    {
+      "slug": "lw-lms-backend-extend",
+      "name": "lw-lms-backend-extend",
+      "domain": "lw-plugins",
+      "description": "Backend extension contract for LW LMS v1.3.0. Use when extending enrollment, access, progress, certificates, automation, analytics, or companion-plugin logic around `lw_lms_after_grant`, `lw_lms_after_revoke`, `lw_lms_pre_grant`, `lw_lms_has_course_access`, `lw_lms_has_lesson_access`, `AccessChecker`, `AccessRepository`, `AccessQueries`, `ProgressRepository`, `ProgressQueries`, `CompletionTracker`, course / lesson CPTs, `wp_lms_progress`, `wp_lms_access`, or `_lw_lms_*` meta. Routes abilities, frontend, and migration topics to sibling skills.",
+      "path": "lw-plugins/lw-lms-backend-extend",
+      "skill_path": "lw-plugins/lw-lms-backend-extend/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/lw-plugins/lw-lms-backend-extend/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/lw-plugins/lw-lms-backend-extend/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/lw-plugins/lw-lms-backend-extend/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/lw-plugins/lw-lms-backend-extend",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "lw-lms",
+        "plugin-version-tested": "1.3.0",
+        "php-min": "8.1",
+        "last-updated": "2026-05-21",
+        "docs": [
+          "https://github.com/lwplugins/lw-lms"
+        ],
+        "source-refs": [
+          "wp-content/plugins/lw-lms/lw-lms.php",
+          "wp-content/plugins/lw-lms/includes/Plugin.php",
+          "wp-content/plugins/lw-lms/includes/Activator.php",
+          "wp-content/plugins/lw-lms/includes/Options.php",
+          "wp-content/plugins/lw-lms/includes/PostTypes/Course.php",
+          "wp-content/plugins/lw-lms/includes/PostTypes/Lesson.php",
+          "wp-content/plugins/lw-lms/includes/Meta/CourseMeta.php",
+          "wp-content/plugins/lw-lms/includes/Meta/LessonMeta.php",
+          "wp-content/plugins/lw-lms/includes/Meta/SubscriptionVariationMeta.php",
+          "wp-content/plugins/lw-lms/includes/Access/AccessChecker.php",
+          "wp-content/plugins/lw-lms/includes/Access/AccessRepository.php",
+          "wp-content/plugins/lw-lms/includes/Access/AccessQueries.php",
+          "wp-content/plugins/lw-lms/includes/Access/AccessGranter.php",
+          "wp-content/plugins/lw-lms/includes/Access/AccessTable.php",
+          "wp-content/plugins/lw-lms/includes/Access/WooCommerceChecker.php",
+          "wp-content/plugins/lw-lms/includes/Access/SubscriptionVariationChecker.php",
+          "wp-content/plugins/lw-lms/includes/Admin/UserProfile.php",
+          "wp-content/plugins/lw-lms/includes/Admin/UserProfile/EnrollmentHandler.php",
+          "wp-content/plugins/lw-lms/includes/Progress/ProgressRepository.php",
+          "wp-content/plugins/lw-lms/includes/Progress/ProgressQueries.php",
+          "wp-content/plugins/lw-lms/includes/Progress/ProgressCalculator.php",
+          "wp-content/plugins/lw-lms/includes/Progress/CompletionTracker.php",
+          "wp-content/plugins/lw-lms/includes/Progress/ProgressSnapshotRepository.php",
+          "wp-content/plugins/lw-lms/includes/Progress/ProgressSnapshotTable.php",
+          "wp-content/plugins/lw-lms/includes/Progress/ProgressSnapshotMigration.php",
+          "wp-content/plugins/lw-lms/includes/Api/Controllers/ProgressController.php",
+          "wp-content/plugins/lw-lms/includes/Api/Controllers/DownloadController.php",
+          "wp-content/plugins/lw-lms/includes/SiteManager/Integration.php",
+          "wp-content/plugins/lw-lms/includes/SiteManager/Abilities/AbilityPermissions.php",
+          "wp-content/plugins/lw-lms/CHANGELOG.md"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 42321,
+        "lines": 662,
+        "sha256": "ecb4750b3aca43fa051e5c5ed4a245499c94aec639eabe4a74a587d650cff754"
+      }
+    },
+    {
+      "slug": "lw-lms-learndash-migration",
+      "name": "lw-lms-learndash-migration",
+      "domain": "lw-plugins",
+      "description": "Plan, run, or review the LW LMS WP-CLI LearnDash migration command `wp lw-lms migrate-learndash` in lw-lms v1.3.0. Use when migrating `sfwd-courses` / `sfwd-lessons`, checking `--dry-run` / `--verbose`, verifying `_lw_lms_migrated_to` mappings, course sections, lesson order, WooCommerce product links, LearnDash video extraction, or safe reruns after partial migration.",
+      "path": "lw-plugins/lw-lms-learndash-migration",
+      "skill_path": "lw-plugins/lw-lms-learndash-migration/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/lw-plugins/lw-lms-learndash-migration/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/lw-plugins/lw-lms-learndash-migration/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/lw-plugins/lw-lms-learndash-migration/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/lw-plugins/lw-lms-learndash-migration",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "lw-lms",
+        "plugin-version-tested": "1.3.0",
+        "php-min": "8.1",
+        "last-updated": "2026-05-21",
+        "docs": [
+          "https://github.com/lwplugins/lw-lms"
+        ],
+        "source-refs": [
+          "wp-content/plugins/lw-lms/includes/Plugin.php",
+          "wp-content/plugins/lw-lms/includes/CLI/MigrateLearnDashCommand.php",
+          "wp-content/plugins/lw-lms/includes/CLI/Migration/CourseMigrator.php",
+          "wp-content/plugins/lw-lms/includes/CLI/Migration/LessonMigrator.php",
+          "wp-content/plugins/lw-lms/includes/CLI/Migration/SectionBuilder.php",
+          "wp-content/plugins/lw-lms/includes/CLI/Migration/LearnDashData.php",
+          "wp-content/plugins/lw-lms/includes/CLI/Migration/VideoExtractor.php",
+          "wp-content/plugins/lw-lms/includes/CLI/Migration/PostCreator.php",
+          "wp-content/plugins/lw-lms/includes/CLI/Migration/MigrationLogger.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 6312,
+        "lines": 115,
+        "sha256": "81c0211f2764f6b9656f24e5668abbba15750cdaba1e442b64ca6e12c6578d12"
+      }
+    },
+    {
+      "slug": "lw-lms-rest-frontend",
+      "name": "lw-lms-rest-frontend",
+      "domain": "lw-plugins",
+      "description": "Build a custom frontend against LW LMS's headless `/wp-json/lms/v1` REST API. Use for React, Vue, Astro, mobile, or theme code that calls `/lms/v1/courses`, `/courses/{id}`, `/lessons/{id}`, `/progress`, `/progress/course/{id}`, or `/download/{id}` and must handle gated `content`, `access.has_access`, `sections`, `lessons_without_section`, per-lesson `accessible`, progress payloads, nonce/app-password auth, and paid-course products/subscriptions/subscription_variations.",
+      "path": "lw-plugins/lw-lms-rest-frontend",
+      "skill_path": "lw-plugins/lw-lms-rest-frontend/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/lw-plugins/lw-lms-rest-frontend/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/lw-plugins/lw-lms-rest-frontend/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/lw-plugins/lw-lms-rest-frontend/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/lw-plugins/lw-lms-rest-frontend",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "lw-lms",
+        "plugin-version-tested": "1.3.0",
+        "php-min": "8.1",
+        "last-updated": "2026-05-21",
+        "docs": [
+          "https://github.com/lwplugins/lw-lms"
+        ],
+        "source-refs": [
+          "wp-content/plugins/lw-lms/includes/Api/RestApi.php",
+          "wp-content/plugins/lw-lms/includes/Api/Controllers/CoursesController.php",
+          "wp-content/plugins/lw-lms/includes/Api/Controllers/LessonsController.php",
+          "wp-content/plugins/lw-lms/includes/Api/Controllers/ProgressController.php",
+          "wp-content/plugins/lw-lms/includes/Api/Controllers/DownloadController.php",
+          "wp-content/plugins/lw-lms/includes/Api/Transformers/CourseTransformer.php",
+          "wp-content/plugins/lw-lms/includes/Api/Transformers/LessonTransformer.php",
+          "wp-content/plugins/lw-lms/includes/Api/Transformers/ProgressTransformer.php",
+          "wp-content/plugins/lw-lms/includes/Access/AccessChecker.php",
+          "wp-content/plugins/lw-lms/includes/Meta/VideoParser.php",
+          "wp-content/plugins/lw-lms/includes/Progress/ProgressCalculator.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 31261,
+        "lines": 749,
+        "sha256": "63e3b5613e9dceeb23e46290d2a908931ee701b2ed7c9ea78e174394596b0215"
+      }
+    },
+    {
+      "slug": "lw-site-manager-extend-abilities",
+      "name": "lw-site-manager-extend-abilities",
+      "domain": "lw-plugins",
+      "description": "Add custom abilities to the LW Site Manager hub via its extension contract — two action hooks (lw_site_manager_register_categories for category labels, lw_site_manager_register_abilities for the abilities themselves; the second receives the central PermissionManager instance so external abilities reuse the typed cap-check methods). Critical pattern — extend AbstractAbilitiesRegistrar to inherit the meta builders (readOnlyMeta / writeMeta / destructiveMeta) and schema builders (paginationSchema / orderingSchema / idSchema / listOutputSchema / entityOutputSchema / successOutputSchema / bulkResultSchema / updateResultSchema). Don't bypass — meta annotations (readonly / destructive / idempotent) are how AI agents reason about ability safety, and inconsistent helpers make the hub surface heterogeneously. The plugin emits NO filters; it's additively extensible only. Use when shipping a companion plugin that adds site-manager/* abilities. Triggers on lw_site_manager_register_abilities, lw_site_manager_register_categories, AbstractAbilitiesRegistrar.",
+      "path": "lw-plugins/lw-site-manager-extend-abilities",
+      "skill_path": "lw-plugins/lw-site-manager-extend-abilities/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/lw-plugins/lw-site-manager-extend-abilities/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/lw-plugins/lw-site-manager-extend-abilities/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/lw-plugins/lw-site-manager-extend-abilities/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/lw-plugins/lw-site-manager-extend-abilities",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "lw-site-manager",
+        "plugin-version-tested": "1.1.22",
+        "php-min": "8.2",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://github.com/lwplugins/lw-site-manager",
+          "https://developer.wordpress.org/apis/abilities-api/"
+        ],
+        "source-refs": [
+          "wp-content/plugins/lw-site-manager/lw-site-manager.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Registrar.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/PermissionManager.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Registrars/AbstractAbilitiesRegistrar.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Registrars/UpdateAbilitiesRegistrar.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Registrars/MaintenanceAbilitiesRegistrar.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Registrars/UserAbilitiesRegistrar.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Registrars/ContentAbilitiesRegistrar.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Definitions/PostAbilities.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Definitions/PageAbilities.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Definitions/CommentAbilities.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Definitions/MediaAbilities.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Definitions/MetaAbilities.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Definitions/SettingsAbilities.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Definitions/TaxonomyAbilities.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Definitions/WooCommerceAbilities.php",
+          "wp-content/plugins/lw-site-manager/src/Services/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 29561,
+        "lines": 513,
+        "sha256": "cf4e721984de446305fa3fd842295e113e21472e0d502fb0bb94a2b9696c99cd"
+      }
+    },
+    {
+      "slug": "lw-site-manager-overview",
+      "name": "lw-site-manager-overview",
+      "domain": "lw-plugins",
+      "description": "Reference for the LW Site Manager plugin (lwplugins/ lw-site-manager) — a WP 6.9+ Abilities-API-native exposure layer that registers 120+ machine-callable abilities under the site-manager/* namespace for AI agents (Claude, ChatGPT, MCP clients) to discover and invoke. Covers updates / plugins / themes / posts / pages / comments / media / users / taxonomies / settings / backups / health / database / cache / WooCommerce. Calling pattern — REST run endpoint is /wp-json/wp-abilities/v1/abilities/{namespace}/{ability}/run with Application Password Basic auth. Important — this is NOT MainWP; the surface and security model are different (per-ability cap-checks via PermissionManager, not a single dashboard token). Header requires PHP 8.2 (not 8.1 as some docs say). Use when calling the plugin's abilities, advising on AI agent integration, or before extending the plugin (see lw-site-manager-extend-abilities). Triggers on site-manager/, lw-site-manager, wp-abilities/v1, AI agent + WP.",
+      "path": "lw-plugins/lw-site-manager-overview",
+      "skill_path": "lw-plugins/lw-site-manager-overview/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/lw-plugins/lw-site-manager-overview/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/lw-plugins/lw-site-manager-overview/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/lw-plugins/lw-site-manager-overview/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/lw-plugins/lw-site-manager-overview",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "lw-site-manager",
+        "plugin-version-tested": "1.1.22",
+        "php-min": "8.2",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://github.com/lwplugins/lw-site-manager",
+          "https://developer.wordpress.org/apis/abilities-api/"
+        ],
+        "source-refs": [
+          "wp-content/plugins/lw-site-manager/lw-site-manager.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Registrar.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/PermissionManager.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Registrars/AbstractAbilitiesRegistrar.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Registrars/UpdateAbilitiesRegistrar.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Registrars/MaintenanceAbilitiesRegistrar.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Registrars/UserAbilitiesRegistrar.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Registrars/ContentAbilitiesRegistrar.php",
+          "wp-content/plugins/lw-site-manager/src/Abilities/Definitions/",
+          "wp-content/plugins/lw-site-manager/src/Services/",
+          "wp-content/plugins/lw-site-manager/docs/abilities/",
+          "wp-content/plugins/lw-site-manager/README.md"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 19261,
+        "lines": 284,
+        "sha256": "738184c0cae4d28e3dd9dfd6476dd1c2f27ca485c2cc384c53e3337b0e0ae91d"
+      }
+    },
+    {
+      "slug": "wp-action-scheduler",
+      "name": "wp-action-scheduler",
+      "domain": "plugin-scaffold",
+      "description": "Design and review Action Scheduler jobs in WordPress plugins using Action Scheduler 3.9.x public APIs - async, single, recurring, and cron-expression actions; action_scheduler_init load timing; hook/args/group naming; unique and priority parameters; idempotent callbacks; chunked workloads; activation/deactivation cleanup; WooCommerce-bundled or standalone dependency usage; admin and WP-CLI debugging; queue runner limits; and safe operational troubleshooting. Use when a plugin schedules background jobs with as_enqueue_async_action, as_schedule_single_action, as_schedule_recurring_action, as_schedule_cron_action, as_get_scheduled_actions, or integrates with WooCommerce background queues.",
+      "path": "plugin-scaffold/wp-action-scheduler",
+      "skill_path": "plugin-scaffold/wp-action-scheduler/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-action-scheduler/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-action-scheduler/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/plugin-scaffold/wp-action-scheduler/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/plugin-scaffold/wp-action-scheduler",
+      "metadata": {
+        "author": "Soczo Kristof",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "action-scheduler",
+        "plugin-version-tested": "3.9.3",
+        "php-min": "7.2",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://actionscheduler.org",
+          "https://actionscheduler.org/api/",
+          "https://github.com/woocommerce/action-scheduler"
+        ]
+      },
+      "resources": [
+        {
+          "path": "references/api-patterns.md",
+          "repo_path": "plugin-scaffold/wp-action-scheduler/references/api-patterns.md",
+          "type": "reference",
+          "bytes": 6850,
+          "sha256": "05ed3860582c292c8e59234c885bf62496939f1f375efe727c42bf833649fe4c"
+        },
+        {
+          "path": "references/operational-debugging.md",
+          "repo_path": "plugin-scaffold/wp-action-scheduler/references/operational-debugging.md",
+          "type": "reference",
+          "bytes": 5929,
+          "sha256": "036402658fddc88910fe8f6bfda2d3097ca52fd9f2537c74f48cdca076ecfcec"
+        }
+      ],
+      "has_reference": true,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 15856,
+        "lines": 398,
+        "sha256": "d7239bc763a7d9cb77d5830bc6c8bf421ade8a3ce5732454257be126d161e559"
+      }
+    },
+    {
+      "slug": "wp-plugin-architecture",
+      "name": "wp-plugin-architecture",
+      "domain": "plugin-scaffold",
+      "description": "Designs and reviews the internal architecture of a WordPress plugin — folder layout, PSR-4 one-class-per-file discipline, Schema/Constants placement, composition-root vs singleton decisions, conditional asset enqueueing, script config via wp_add_inline_script, and prefixed custom-hook naming. Use when scaffolding includes/src, reviewing class organization, asset enqueue code, repeated strings, or \"should I make this a singleton\" decisions.",
+      "path": "plugin-scaffold/wp-plugin-architecture",
+      "skill_path": "plugin-scaffold/wp-plugin-architecture/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-architecture/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-architecture/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/plugin-scaffold/wp-plugin-architecture/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/plugin-scaffold/wp-plugin-architecture",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.3 - 6.9",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://developer.wordpress.org/reference/functions/wp_enqueue_script/",
+          "https://developer.wordpress.org/reference/functions/wp_add_inline_script/",
+          "https://developer.wordpress.org/reference/hooks/admin_enqueue_scripts/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 16034,
+        "lines": 331,
+        "sha256": "7f1538d9dee094da3f9026f77ce7fb8cc1820aa98af5fdf4a77bb87f6b8cd606"
+      }
+    },
+    {
+      "slug": "wp-plugin-assets-loading",
+      "name": "wp-plugin-assets-loading",
+      "domain": "plugin-scaffold",
+      "description": "Register and enqueue WordPress plugin scripts/styles with modern loading behavior, especially WP 7.0 classic-script module dependencies, script module translations, fetchpriority support, script module args, footer placement, inline style limits, and removal of legacy IE conditional asset support. Covers wp_enqueue_script args strategy/in_footer/fetchpriority/module_dependencies, wp_register_script_module / wp_enqueue_script_module args, wp_set_script_module_translations, wp_script_add_data, wp_style_add_data, dependency handles, conditional enqueueing on the right hook, and avoiding global frontend/admin asset bloat. Use when adding or reviewing plugin JS/CSS enqueue code.",
+      "path": "plugin-scaffold/wp-plugin-assets-loading",
+      "skill_path": "plugin-scaffold/wp-plugin-assets-loading/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-assets-loading/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-assets-loading/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/plugin-scaffold/wp-plugin-assets-loading/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/plugin-scaffold/wp-plugin-assets-loading",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.3 - 7.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-21",
+        "docs": [
+          "https://make.wordpress.org/core/2025/11/18/wordpress-6-9-frontend-performance-field-guide/",
+          "https://developer.wordpress.org/reference/functions/wp_enqueue_script/",
+          "https://developer.wordpress.org/reference/functions/wp_enqueue_style/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 9611,
+        "lines": 255,
+        "sha256": "c407162dc411515838376b185f6d0dc8e13b8c29da6d8d21a768470cf165afd8"
+      }
+    },
+    {
+      "slug": "wp-plugin-bootstrap",
+      "name": "wp-plugin-bootstrap",
+      "domain": "plugin-scaffold",
+      "description": "Scaffolds and reviews the main entry-point PHP file of a WordPress plugin — header (with Requires Plugins for WP 6.5+), ABSPATH guard, file/path/url/version constants, Composer + PSR-4 with manual spl_autoload_register fallback, register_activation_hook requirements check, Plugin class instantiation on plugins_loaded, and the WP 6.7+ rule that translation functions must not trigger before after_setup_theme. Use when scaffolding a new plugin or reviewing its main file. Triggers on Plugin Name headers, register_activation_hook, Requires Plugins, spl_autoload_register, plugins_loaded, or composer.json at the plugin root.",
+      "path": "plugin-scaffold/wp-plugin-bootstrap",
+      "skill_path": "plugin-scaffold/wp-plugin-bootstrap/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-bootstrap/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-bootstrap/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/plugin-scaffold/wp-plugin-bootstrap/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/plugin-scaffold/wp-plugin-bootstrap",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.5 - 6.9",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://developer.wordpress.org/plugins/plugin-basics/header-requirements/",
+          "https://developer.wordpress.org/plugins/plugin-basics/best-practices/",
+          "https://developer.wordpress.org/reference/functions/register_activation_hook/",
+          "https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 18840,
+        "lines": 337,
+        "sha256": "eeb902e4860d1681449af005078919791be0f637d720ccd8ef3de0fd566c9b8b"
+      }
+    },
+    {
+      "slug": "wp-plugin-cron",
+      "name": "wp-plugin-cron",
+      "domain": "plugin-scaffold",
+      "description": "Designs and reviews scheduled/background work in WordPress plugins: wp_schedule_event, wp_schedule_single_event, cron_schedules, wp_next_scheduled guards, activation scheduling, deactivation cleanup, WP-Cron pseudo-cron timing, DISABLE_WP_CRON/system cron, multisite per-blog cron, idempotent callbacks, chunking, and Action Scheduler graduation. Use when adding scheduled jobs, debugging late/duplicate cron events, or deciding between WP cron and Action Scheduler.",
+      "path": "plugin-scaffold/wp-plugin-cron",
+      "skill_path": "plugin-scaffold/wp-plugin-cron/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-cron/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-cron/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/plugin-scaffold/wp-plugin-cron/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/plugin-scaffold/wp-plugin-cron",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.5 - 6.9",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://developer.wordpress.org/plugins/cron/",
+          "https://developer.wordpress.org/reference/functions/wp_schedule_event/",
+          "https://developer.wordpress.org/reference/functions/wp_schedule_single_event/",
+          "https://developer.wordpress.org/reference/hooks/cron_schedules/",
+          "https://actionscheduler.org"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 17721,
+        "lines": 336,
+        "sha256": "c0048667561c367a8a35fd4022a4c1491b7624baec3369e349f17990e4dc6399"
+      }
+    },
+    {
+      "slug": "wp-plugin-dto",
+      "name": "wp-plugin-dto",
+      "domain": "plugin-scaffold",
+      "description": "Design and review native DTOs in WordPress plugins without requiring better-data - immutable data carriers, explicit from_array hydration, strict coercion instead of unchecked casts, WP_Error validation failures, sensitive-field discipline, nested DTO arrays, and clear separation from repositories, WP models, presenters, REST controllers, and HTML views. Use when a plugin introduces FooDto, request DTOs, settings DTOs, value objects, admin-row data shapes, REST response source objects, or when reviewing code that passes raw arrays, stdClass, WP_Post, WC_Order, $_POST, post meta, or option arrays through multiple layers. Mentions better-data only as an optional higher-level library; this skill is for native implementations.",
+      "path": "plugin-scaffold/wp-plugin-dto",
+      "skill_path": "plugin-scaffold/wp-plugin-dto/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-dto/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-dto/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/plugin-scaffold/wp-plugin-dto/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/plugin-scaffold/wp-plugin-dto",
+      "metadata": {
+        "author": "Soczo Kristof",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.3 - 6.9",
+        "php-min": "7.4",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://developer.wordpress.org/plugins/security/securing-input/",
+          "https://developer.wordpress.org/plugins/security/validating-sanitizing-escaping/",
+          "https://developer.wordpress.org/reference/classes/wp_error/",
+          "https://developer.wordpress.org/reference/functions/wp_unslash/"
+        ]
+      },
+      "resources": [
+        {
+          "path": "references/before-after-raw-array.md",
+          "repo_path": "plugin-scaffold/wp-plugin-dto/references/before-after-raw-array.md",
+          "type": "reference",
+          "bytes": 3754,
+          "sha256": "a300f8d160145133403f25b00cb1e0a248087bef93357eb360c7a379312f5f80"
+        },
+        {
+          "path": "references/native-dto-patterns.md",
+          "repo_path": "plugin-scaffold/wp-plugin-dto/references/native-dto-patterns.md",
+          "type": "reference",
+          "bytes": 8168,
+          "sha256": "d81fe0285784c0673d4233ac8cd94170f701a145d7b8887d0f84d7e260257212"
+        }
+      ],
+      "has_reference": true,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 10335,
+        "lines": 227,
+        "sha256": "ebcb69056cf6456acda7216a12f0803fcb3dec6b647080acf42ae0b60c2e000d"
+      }
+    },
+    {
+      "slug": "wp-plugin-hooks",
+      "name": "wp-plugin-hooks",
+      "domain": "plugin-scaffold",
+      "description": "Design custom action/filter hooks emitted by a plugin: action vs filter semantics, prefixed names, docblocks, parameter stability, *_ref_array forwarding, and deprecated hook migration. Use when adding, reviewing, evolving, or deprecating a public hook surface. Triggers on do_action, apply_filters, apply_filters_deprecated, do_action_deprecated, apply_filters_ref_array, do_action_ref_array, did_action, did_filter, or hook @since docblocks.",
+      "path": "plugin-scaffold/wp-plugin-hooks",
+      "skill_path": "plugin-scaffold/wp-plugin-hooks/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-hooks/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-hooks/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/plugin-scaffold/wp-plugin-hooks/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/plugin-scaffold/wp-plugin-hooks",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.5 - 6.9",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://developer.wordpress.org/plugins/hooks/",
+          "https://developer.wordpress.org/reference/functions/apply_filters/",
+          "https://developer.wordpress.org/reference/functions/do_action/",
+          "https://developer.wordpress.org/reference/functions/apply_filters_deprecated/",
+          "https://developer.wordpress.org/reference/functions/do_action_deprecated/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 15233,
+        "lines": 294,
+        "sha256": "511d652c37defacc7b20cc37c39b5f06494684b58c0e9fdc6a0efd6c2085e488"
+      }
+    },
+    {
+      "slug": "wp-plugin-lifecycle",
+      "name": "wp-plugin-lifecycle",
+      "domain": "plugin-scaffold",
+      "description": "Designs and reviews the three lifecycle events of a WordPress plugin — activation (one-shot setup, dbDelta, add_option seeding, cron schedule, cap seeding), deactivation (reversible cleanup, cron clear via wp_unschedule_hook, never delete user data), and uninstall.php (standalone file, WP_UNINSTALL_PLUGIN guard, no autoloader, full data removal). Multisite-aware patterns using the $network_wide / $network_deactivating callback args, plus the recommendation against register_uninstall_hook in favor of uninstall.php. Use when scaffolding a plugin or debugging ghost cron events / orphan options. Triggers on register_activation_hook, register_deactivation_hook, uninstall.php, WP_UNINSTALL_PLUGIN, dbDelta, wp_unschedule_hook, switch_to_blog.",
+      "path": "plugin-scaffold/wp-plugin-lifecycle",
+      "skill_path": "plugin-scaffold/wp-plugin-lifecycle/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-lifecycle/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-lifecycle/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/plugin-scaffold/wp-plugin-lifecycle/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/plugin-scaffold/wp-plugin-lifecycle",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.5 - 6.9",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://developer.wordpress.org/plugins/plugin-basics/uninstall-methods/",
+          "https://developer.wordpress.org/reference/functions/register_activation_hook/",
+          "https://developer.wordpress.org/reference/functions/register_deactivation_hook/",
+          "https://developer.wordpress.org/reference/functions/wp_unschedule_hook/",
+          "https://developer.wordpress.org/reference/functions/dbDelta/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 19077,
+        "lines": 353,
+        "sha256": "d52c0f7ff6b6022b87ac9afdc2b9831d114752e1ec12b66ec6fc91da656c5b37"
+      }
+    },
+    {
+      "slug": "wp-plugin-options-storage",
+      "name": "wp-plugin-options-storage",
+      "domain": "plugin-scaffold",
+      "description": "Picks the right WordPress storage primitive for plugin data: options, user/post/term/comment meta, transients, site options, site transients, or custom tables. Covers grouped settings, autoload management, transient TTL rules, serialized/JSON blob trade-offs, multisite storage caveats, and naming conventions. Use when scaffolding settings, choosing persistence for plugin-owned data, or auditing update_option/get_option/get_post_meta/set_transient/autoload usage.",
+      "path": "plugin-scaffold/wp-plugin-options-storage",
+      "skill_path": "plugin-scaffold/wp-plugin-options-storage/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-options-storage/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-options-storage/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/plugin-scaffold/wp-plugin-options-storage/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/plugin-scaffold/wp-plugin-options-storage",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.5 - 6.9",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://developer.wordpress.org/reference/functions/add_option/",
+          "https://developer.wordpress.org/reference/functions/get_option/",
+          "https://developer.wordpress.org/reference/functions/get_post_meta/",
+          "https://developer.wordpress.org/reference/functions/set_transient/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 16917,
+        "lines": 256,
+        "sha256": "73f2427a8390bc41a17aeee7a9182a5b3dd022a8d52d06cc658eeb4ddf174677"
+      }
+    },
+    {
+      "slug": "wp-plugin-presenter",
+      "name": "wp-plugin-presenter",
+      "domain": "plugin-scaffold",
+      "description": "Design and review native presenter classes in WordPress plugins without requiring better-data - converting DTOs or domain objects into REST arrays, admin table rows, JS config payloads, email variables, and public view models with allowlisted fields, context methods, redaction by default, locale/date/number formatting, no DTO mutation, and correct WordPress escaping boundaries. Use when adding FooPresenter, response mappers, admin-row arrays, wp_send_json payloads, rest_ensure_response data, wp_add_inline_script config, or when code returns raw DTOs, WP_Post, WC_Order, get_object_vars, json_encode, or unescaped HTML from controllers.",
+      "path": "plugin-scaffold/wp-plugin-presenter",
+      "skill_path": "plugin-scaffold/wp-plugin-presenter/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-presenter/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-presenter/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/plugin-scaffold/wp-plugin-presenter/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/plugin-scaffold/wp-plugin-presenter",
+      "metadata": {
+        "author": "Soczo Kristof",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.3 - 6.9",
+        "php-min": "7.4",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://developer.wordpress.org/plugins/security/validating-sanitizing-escaping/",
+          "https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/",
+          "https://developer.wordpress.org/reference/functions/rest_ensure_response/",
+          "https://developer.wordpress.org/reference/functions/wp_json_encode/"
+        ]
+      },
+      "resources": [
+        {
+          "path": "references/before-after-controller-output.md",
+          "repo_path": "plugin-scaffold/wp-plugin-presenter/references/before-after-controller-output.md",
+          "type": "reference",
+          "bytes": 3420,
+          "sha256": "8a46587aa522a3f13e3d2dd457ade6be9a158c517c8b0b2dc604327dc2e047f3"
+        },
+        {
+          "path": "references/presenter-context-patterns.md",
+          "repo_path": "plugin-scaffold/wp-plugin-presenter/references/presenter-context-patterns.md",
+          "type": "reference",
+          "bytes": 5204,
+          "sha256": "b81d223c7cf95b5c9adab9635560696f127c5bb5704be20f8be2bb03c4330251"
+        }
+      ],
+      "has_reference": true,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 8930,
+        "lines": 208,
+        "sha256": "2734547d391183977e80bf0b8eac6dadc52cd3fbfd20969f7c4cf239e58b1e2f"
+      }
+    },
+    {
+      "slug": "wp-plugin-rewrite-rules",
+      "name": "wp-plugin-rewrite-rules",
+      "domain": "plugin-scaffold",
+      "description": "Design and review custom WordPress URL rewrites: add_rewrite_rule, add_rewrite_tag, query_vars, CPT/taxonomy rewrite slugs, add_rewrite_endpoint, soft vs hard flushes, rewrite_rules cache behavior, and the rule that flush_rewrite_rules() must not run on every request. Use for custom pretty URLs, CPT permalink 404s, endpoint rewrites, and code containing flush_rewrite_rules or add_rewrite_rule.",
+      "path": "plugin-scaffold/wp-plugin-rewrite-rules",
+      "skill_path": "plugin-scaffold/wp-plugin-rewrite-rules/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-rewrite-rules/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/plugin-scaffold/wp-plugin-rewrite-rules/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/plugin-scaffold/wp-plugin-rewrite-rules/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/plugin-scaffold/wp-plugin-rewrite-rules",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.5 - 6.9",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://developer.wordpress.org/reference/functions/add_rewrite_rule/",
+          "https://developer.wordpress.org/reference/functions/flush_rewrite_rules/",
+          "https://developer.wordpress.org/reference/functions/add_rewrite_endpoint/",
+          "https://developer.wordpress.org/reference/hooks/query_vars/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 16987,
+        "lines": 315,
+        "sha256": "203d77007f1abbfd2282c8cdcc9666dcf099313aeb8926355d98d7df1a799179"
+      }
+    },
+    {
+      "slug": "wc-action-scheduler-jobs",
+      "name": "wc-action-scheduler-jobs",
+      "domain": "woocommerce",
+      "description": "Queue and run WooCommerce background jobs with Action Scheduler. Covers `as_enqueue_async_action`, `as_schedule_single_action`, `as_schedule_recurring_action`, `as_schedule_cron_action`, `as_has_scheduled_action`, `as_next_scheduled_action`, `as_unschedule_action`, `as_unschedule_all_actions`, groups, scalar args, WP-CLI runner, activation/deactivation scheduling, batching, idempotency, and the important WC 10.8 DB-store gotcha that `$unique` prevents another pending/running action with the same hook and group, not one per argument set. Use when moving slow order/product/customer work out of requests or status hooks.",
+      "path": "woocommerce/wc-action-scheduler-jobs",
+      "skill_path": "woocommerce/wc-action-scheduler-jobs/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-action-scheduler-jobs/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-action-scheduler-jobs/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wc-action-scheduler-jobs/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wc-action-scheduler-jobs",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce",
+        "plugin-version-tested": "10.8.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-27",
+        "docs": [
+          "https://actionscheduler.org/"
+        ],
+        "source-refs": [
+          "wp-content/plugins/woocommerce/packages/action-scheduler/functions.php",
+          "wp-content/plugins/woocommerce/packages/action-scheduler/classes/ActionScheduler_ActionFactory.php",
+          "wp-content/plugins/woocommerce/packages/action-scheduler/classes/data-stores/ActionScheduler_DBStore.php",
+          "wp-content/plugins/woocommerce/packages/action-scheduler/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php",
+          "wp-content/plugins/woocommerce/packages/action-scheduler/classes/WP_CLI/Action_Command.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 8699,
+        "lines": 208,
+        "sha256": "9cf50495cbb269205b3b4f198a6d27d5fc9287d21ed1ab9c88455e36ae383754"
+      }
+    },
+    {
+      "slug": "wc-cart-checkout-classic",
+      "name": "wc-cart-checkout-classic",
+      "domain": "woocommerce",
+      "description": "Customize the classic WooCommerce cart and shortcode checkout with `woocommerce_add_cart_item_data`, `woocommerce_get_item_data`, `woocommerce_before_calculate_totals`, `woocommerce_cart_calculate_fees`, `woocommerce_checkout_fields`, `woocommerce_after_checkout_validation`, `woocommerce_checkout_update_order_meta`, and `woocommerce_checkout_create_order_line_item`. Covers cart-key merging, absolute price mutation, fees, classic checkout fields, order-line meta vs order meta, HPOS-safe order saves, and the Checkout Block / Store API boundary. Use when adding product options, custom cart data, fees, classic checkout fields, validation, or debugging missing/duplicated cart/order item data.",
+      "path": "woocommerce/wc-cart-checkout-classic",
+      "skill_path": "woocommerce/wc-cart-checkout-classic/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-cart-checkout-classic/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-cart-checkout-classic/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wc-cart-checkout-classic/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wc-cart-checkout-classic",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce",
+        "plugin-version-tested": "10.8.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-27",
+        "docs": [
+          "https://woocommerce.com/document/tutorial-customising-checkout-fields-using-actions-and-filters/"
+        ],
+        "source-refs": [
+          "wp-content/plugins/woocommerce/includes/class-wc-cart.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-checkout.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-form-handler.php",
+          "wp-content/plugins/woocommerce/includes/wc-template-functions.php",
+          "wp-content/plugins/woocommerce/src/StoreApi/Utilities/CartController.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 10310,
+        "lines": 275,
+        "sha256": "082dc0b4a38e1f160e35fdbf7d17f3b16dd43285c9cd934ec1fe913efe6f8a0a"
+      }
+    },
+    {
+      "slug": "wc-coupon-dynamic",
+      "name": "wc-coupon-dynamic",
+      "domain": "woocommerce",
+      "description": "Synthesize WooCommerce coupons at runtime without creating shop_coupon posts in the DB — via the woocommerce_get_shop_coupon_data filter, the hidden-but-powerful virtual-coupon mechanism. Filter fires inside WC_Coupon::__construct, and a non-false return becomes a fully functional coupon read through read_manual_coupon. Plus custom discount types via woocommerce_coupon_discount_types and woocommerce_coupon_get_discount_amount, and the validation triple woocommerce_coupon_is_valid / _is_valid_for_cart / _is_valid_for_product. Use when implementing rule-driven coupons (auto-apply X% to logged-in users, code-pattern detection like LOYALTY-42, external CRM integration that hands out codes), without populating wp_posts. The AI-deficient pattern; most LLMs don't know dynamic coupons exist. Triggers on woocommerce_get_shop_coupon_data, woocommerce_coupon_discount_types, woocommerce_coupon_get_discount_amount, read_manual_coupon, virtual coupon, dynamic coupon in WC context.",
+      "path": "woocommerce/wc-coupon-dynamic",
+      "skill_path": "woocommerce/wc-coupon-dynamic/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-coupon-dynamic/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-coupon-dynamic/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wc-coupon-dynamic/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wc-coupon-dynamic",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce",
+        "plugin-version-tested": "10.7",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://woocommerce.com/document/woocommerce-coupons/"
+        ],
+        "source-refs": [
+          "wp-content/plugins/woocommerce/includes/class-wc-coupon.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-discounts.php",
+          "wp-content/plugins/woocommerce/includes/wc-coupon-functions.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-cart.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 21552,
+        "lines": 393,
+        "sha256": "1454c15d0129d5531282c3b2ead6f0c14ad82e5899bcca31a1c3726a0e0c2666"
+      }
+    },
+    {
+      "slug": "wc-customer-and-sessions",
+      "name": "wc-customer-and-sessions",
+      "domain": "woocommerce",
+      "description": "Use WooCommerce's customer and session APIs correctly — WC ships its own session handler (WC_Session_Handler, single wp_woocommerce_sessions table for both guests and logged-in users) and its own customer object (WC_Customer via WC()->customer). Avoid $_SESSION, direct setcookie, and user_meta for guest/session state. Use WC()->session->set/get for ephemeral visitor data, WC()->customer->get_billing_* for active customer context including guests, and new WC_Customer($user_id) for one-off loads. WC()->session auto-inits only on frontend/admin-ajax; REST, cron, and WP-CLI must call wc_load_cart() explicitly, while Store API cart/checkout routes can use Cart-Token sessions. Use when storing per-visitor state, reading billing data, or debugging session loss across cache/REST/cron. Triggers on WC_Session, WC_Session_Handler, WC_Customer, WC()->session, WC()->customer, wp_woocommerce_sessions.",
+      "path": "woocommerce/wc-customer-and-sessions",
+      "skill_path": "woocommerce/wc-customer-and-sessions/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-customer-and-sessions/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-customer-and-sessions/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wc-customer-and-sessions/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wc-customer-and-sessions",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce",
+        "plugin-version-tested": "10.8.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-26",
+        "docs": [
+          "https://woocommerce.com/document/woocommerce-data-storage/"
+        ],
+        "source-refs": [
+          "wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-session.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-session-handler.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-customer.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-cart-session.php",
+          "wp-content/plugins/woocommerce/includes/class-woocommerce.php",
+          "wp-content/plugins/woocommerce/includes/wc-core-functions.php",
+          "wp-content/plugins/woocommerce/src/StoreApi/Authentication.php",
+          "wp-content/plugins/woocommerce/src/StoreApi/SessionHandler.php",
+          "wp-content/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php",
+          "wp-content/plugins/woocommerce/src/StoreApi/Utilities/CartController.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 24039,
+        "lines": 376,
+        "sha256": "1e7ba1da73808f1b04a668c8e37fa2ffe233047e3e11a3b9cab78e569080cb79"
+      }
+    },
+    {
+      "slug": "wc-emails-classic",
+      "name": "wc-emails-classic",
+      "domain": "woocommerce",
+      "description": "Customize WooCommerce transactional emails the classic PHP-template way (NOT the block email editor) — extend WC_Email, declare $id / $title / $template_html / $template_plain / $placeholders, hook trigger() to a woocommerce_order_status_*_notification action, register via the woocommerce_email_classes filter. Plus the canonical template-override pattern (copy templates/emails/*.php to your theme's /woocommerce/emails/ folder; wc_get_template resolves them automatically), and the get_default_subject / get_default_heading override pattern for admin-customizable strings. Use when adding a new transactional email (custom shipped notification, vendor split, internal alert), overriding an existing template, or customizing strings that the admin Settings cannot reach. Triggers on WC_Email, woocommerce_email_classes, woocommerce_order_status_*_notification, wc_get_template_html, template_html / template_plain in WC context, \"transactional email\" / \"send WooCommerce email programmatically\".",
+      "path": "woocommerce/wc-emails-classic",
+      "skill_path": "woocommerce/wc-emails-classic/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-emails-classic/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-emails-classic/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wc-emails-classic/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wc-emails-classic",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce",
+        "plugin-version-tested": "10.8.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-26",
+        "docs": [
+          "https://woocommerce.com/document/template-structure/"
+        ],
+        "source-refs": [
+          "wp-content/plugins/woocommerce/includes/class-wc-emails.php",
+          "wp-content/plugins/woocommerce/includes/emails/class-wc-email.php",
+          "wp-content/plugins/woocommerce/includes/emails/class-wc-email-customer-processing-order.php",
+          "wp-content/plugins/woocommerce/includes/emails/class-wc-email-customer-review-request.php",
+          "wp-content/plugins/woocommerce/includes/wc-core-functions.php",
+          "wp-content/plugins/woocommerce/templates/emails/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 21674,
+        "lines": 376,
+        "sha256": "455b137a45021c1830eff566fd51556df0ba289024f3b0ac1ef714fc71f36db6"
+      }
+    },
+    {
+      "slug": "wc-hpos-compatibility",
+      "name": "wc-hpos-compatibility",
+      "domain": "woocommerce",
+      "description": "Make a WooCommerce plugin HPOS-compatible (High-Performance Order Storage, default-on in WC 10.x) — declare via FeaturesUtil::declare_compatibility on before_woocommerce_init, replace $wpdb->postmeta / WP_Query order code with wc_get_orders + WC_Order::get_meta / update_meta_data, gate runtime branches on OrderUtil::custom_orders_table_usage_is_enabled, use OrderUtil::get_order_admin_screen for screen IDs while branching order-list hook names by HPOS vs legacy mode. Use when scaffolding an order-touching plugin, auditing existing code for HPOS readiness, or fixing post-WC-10 silent breakage. Triggers on shop_order, get_post_meta with order context, FeaturesUtil, OrderUtil, custom_order_tables, before_woocommerce_init.",
+      "path": "woocommerce/wc-hpos-compatibility",
+      "skill_path": "woocommerce/wc-hpos-compatibility/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-hpos-compatibility/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-hpos-compatibility/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wc-hpos-compatibility/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wc-hpos-compatibility",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce",
+        "plugin-version-tested": "10.8.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-26",
+        "docs": [
+          "https://developer.woocommerce.com/docs/hpos/",
+          "https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book"
+        ],
+        "source-refs": [
+          "wp-content/plugins/woocommerce/src/Utilities/FeaturesUtil.php",
+          "wp-content/plugins/woocommerce/src/Utilities/OrderUtil.php",
+          "wp-content/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php",
+          "wp-content/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php",
+          "wp-content/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php",
+          "wp-content/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php",
+          "wp-content/plugins/woocommerce/includes/wc-update-functions.php",
+          "wp-content/plugins/woocommerce/src/Admin/Features/Fulfillments/FulfillmentsRenderer.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 22034,
+        "lines": 388,
+        "sha256": "cb37430a9e4cf93e45823690713381cfaf76ac3c2bea526dcfa45891831013c1"
+      }
+    },
+    {
+      "slug": "wc-order-lifecycle-and-items",
+      "name": "wc-order-lifecycle-and-items",
+      "domain": "woocommerce",
+      "description": "Work safely with WooCommerce order statuses, payment completion, status hooks, order items, line-item meta, totals, and stock side effects. Covers `payment_complete()` vs `update_status()`, `woocommerce_order_status_*` hook ordering and args, `woocommerce_order_status_changed`, `woocommerce_order_payment_status_changed`, `WC_Order_Item_Product`, `add_item()`, `calculate_totals()`, stock reduction/restoration hooks, HPOS-safe CRUD, and why not to instantiate base `WC_Order_Item`. Use when reacting to orders, adding/editing items, changing statuses, provisioning, fulfillment, stock logic, or debugging paid orders that skipped lifecycle side effects.",
+      "path": "woocommerce/wc-order-lifecycle-and-items",
+      "skill_path": "woocommerce/wc-order-lifecycle-and-items/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-order-lifecycle-and-items/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-order-lifecycle-and-items/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wc-order-lifecycle-and-items/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wc-order-lifecycle-and-items",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce",
+        "plugin-version-tested": "10.8.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-27",
+        "docs": [
+          "https://woocommerce.github.io/code-reference/classes/WC-Order.html"
+        ],
+        "source-refs": [
+          "wp-content/plugins/woocommerce/includes/class-wc-order.php",
+          "wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-order.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-order-item.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-order-item-product.php",
+          "wp-content/plugins/woocommerce/includes/wc-order-functions.php",
+          "wp-content/plugins/woocommerce/includes/wc-stock-functions.php",
+          "wp-content/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 9001,
+        "lines": 202,
+        "sha256": "ac878096f662998817bbfedd276a09f89232c03f2b2dc9f9d87056f23d4b4fc0"
+      }
+    },
+    {
+      "slug": "wc-payment-gateway",
+      "name": "wc-payment-gateway",
+      "domain": "woocommerce",
+      "description": "Register a custom WooCommerce payment gateway — extend WC_Payment_Gateway, declare $id / $title / $supports, implement process_payment returning array(result, redirect), optionally process_refund when refunds is in supports, register via the woocommerce_payment_gateways filter. Canonical gotcha: payment_complete vs update_status — payment_complete runs the paid-order state machine (status, transaction id, session flag, payment-complete action), update_status only changes status. Includes the forgotten WC()->cart->empty_cart() call and Store API payment requirements for Checkout Blocks. Use when integrating/reviewing gateways or debugging \"payment succeeded but cart didn't clear\" / \"order stuck in pending\". Triggers on WC_Payment_Gateway, woocommerce_payment_gateways, process_payment, process_refund, payment_complete, get_return_url, woocommerce_payment_complete_order_status, woocommerce_store_api_register_payment_requirements.",
+      "path": "woocommerce/wc-payment-gateway",
+      "skill_path": "woocommerce/wc-payment-gateway/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-payment-gateway/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-payment-gateway/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wc-payment-gateway/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wc-payment-gateway",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce",
+        "plugin-version-tested": "10.8.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-26",
+        "docs": [
+          "https://woocommerce.com/document/payment-gateway-api/"
+        ],
+        "source-refs": [
+          "wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php",
+          "wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-payment-gateways.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-order.php",
+          "wp-content/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php",
+          "wp-content/plugins/woocommerce/includes/gateways/cheque/class-wc-gateway-cheque.php",
+          "wp-content/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php",
+          "wp-content/plugins/woocommerce/includes/class-woocommerce.php",
+          "wp-content/plugins/woocommerce/src/StoreApi/Schemas/ExtendSchema.php",
+          "wp-content/plugins/woocommerce/assets/client/blocks/wc-blocks-registry.js"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 27347,
+        "lines": 487,
+        "sha256": "d7693a2bcb8b88ebe41ce7b77d773accfb7b2925be3edf96e58a8cc5c190b6c0"
+      }
+    },
+    {
+      "slug": "wc-payment-tokens",
+      "name": "wc-payment-tokens",
+      "domain": "woocommerce",
+      "description": "Store and use WooCommerce saved payment methods through `WC_Payment_Tokens` and `WC_Payment_Token_CC` safely. Covers provider token vs card data, tokenization gateway support, creating/updating/deleting/defaulting tokens, My Account nonce and ownership checks, `get_customer_tokens`, `get_customer_default_token`, `get_order_tokens`, attaching tokens to orders, gateway ID filtering, custom token tables, hooks, HPOS-safe order use, and checkout saved-token validation. Use when building saved cards, charging a saved method, add-payment-method flows, token migrations, token deletion/default endpoints, or gateway tokenization.",
+      "path": "woocommerce/wc-payment-tokens",
+      "skill_path": "woocommerce/wc-payment-tokens/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-payment-tokens/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-payment-tokens/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wc-payment-tokens/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wc-payment-tokens",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce",
+        "plugin-version-tested": "10.8.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-27",
+        "docs": [
+          "https://woocommerce.com/document/payment-gateway-api/"
+        ],
+        "source-refs": [
+          "wp-content/plugins/woocommerce/includes/class-wc-payment-tokens.php",
+          "wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-payment-token.php",
+          "wp-content/plugins/woocommerce/includes/payment-tokens/class-wc-payment-token-cc.php",
+          "wp-content/plugins/woocommerce/includes/payment-tokens/class-wc-payment-token-echeck.php",
+          "wp-content/plugins/woocommerce/includes/data-stores/class-wc-payment-token-data-store.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-form-handler.php",
+          "wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php",
+          "wp-content/plugins/woocommerce/includes/gateways/class-wc-payment-gateway-cc.php",
+          "wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-order.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 11188,
+        "lines": 264,
+        "sha256": "29e162dce8ded18399c210e0218ca51eecc35bc41e86c98c64971ed8c34d633d"
+      }
+    },
+    {
+      "slug": "wc-product-search-select",
+      "name": "wc-product-search-select",
+      "domain": "woocommerce",
+      "description": "Builds a WooCommerce-style AJAX product search select (the selectWoo / wooselect dropdown) — class=\"wc-product-search\" + the data-action attribute pointing to woocommerce_json_search_products (products only) or woocommerce_json_search_products_and_variations (products AND variations, often the right choice). Pre-selected items rendered server-side as <option selected> via wc_get_product() + get_formatted_name(); WC's wc-enhanced-select script auto-enqueued on WC admin screens, explicit enqueue required on non-WC pages. Solves the \"load 20k products into a select\" antipattern AI assistants commonly emit. Use when adding a product picker meta box, a custom WC admin page selector, or any UI where the user must search and pick from many products. Triggers on wc-product-search, woocommerce_json_search_products, woocommerce_json_search_products_and_variations, selectWoo, wc-enhanced-select, \"select2 products in WooCommerce\", or product-picker meta box scaffolding.",
+      "path": "woocommerce/wc-product-search-select",
+      "skill_path": "woocommerce/wc-product-search-select/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-product-search-select/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-product-search-select/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wc-product-search-select/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wc-product-search-select",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce",
+        "plugin-version-tested": "10.8.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-26",
+        "docs": [
+          "https://github.com/woocommerce/selectWoo",
+          "https://woocommerce.com/document/woocommerce-json-search/"
+        ],
+        "source-refs": [
+          "wp-content/plugins/woocommerce/includes/class-wc-ajax.php",
+          "wp-content/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php",
+          "wp-content/plugins/woocommerce/includes/admin/class-wc-admin-assets.php",
+          "wp-content/plugins/woocommerce/assets/js/admin/wc-enhanced-select.js"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 16322,
+        "lines": 285,
+        "sha256": "4f36476a91de09f2e8e86e6523fb34f45286163f6bc494be846bba95d6d78ebd"
+      }
+    },
+    {
+      "slug": "wc-rest-api-v4",
+      "name": "wc-rest-api-v4",
+      "domain": "woocommerce",
+      "description": "Use the WooCommerce REST API v4 (namespace wc/v4, since WC 10.2) alongside or in place of v3 — verified route catalog (Customers, Orders, Refunds, Products, ShippingZones with DELETE, ShippingZoneMethod, Fulfillments, segmented Settings under /wc/v4/settings/<group>), the hook prefix pattern woocommerce_rest_api_v4_<route>_*, shared error codes, and the RestApiCache trait (WC 10.5+) for endpoint response caching. The v4 AbstractController lives under the Internal namespace and is NOT a public extension surface; plugin-defined REST routes use WP_REST_Controller directly. Use when calling WC REST endpoints, when picking v3 vs v4, or when reviewing /wc/v3/ URLs that now have v4 equivalents. Triggers on wc/v4, /wc/v4/, woocommerce_rest_api_v4_*, RestApiCache, customer-owned Woo endpoints, REST API v4 in WooCommerce context.",
+      "path": "woocommerce/wc-rest-api-v4",
+      "skill_path": "woocommerce/wc-rest-api-v4/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-rest-api-v4/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-rest-api-v4/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wc-rest-api-v4/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wc-rest-api-v4",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce",
+        "plugin-version-tested": "10.8.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-26",
+        "docs": [
+          "https://woocommerce.com/document/woocommerce-rest-api/"
+        ],
+        "source-refs": [
+          "wp-content/plugins/woocommerce/includes/wc-rest-functions.php",
+          "wp-content/plugins/woocommerce/src/Internal/RestApi/Routes/V4/AbstractController.php",
+          "wp-content/plugins/woocommerce/src/Internal/RestApi/Routes/V4/",
+          "wp-content/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Orders/CollectionQuery.php",
+          "wp-content/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Products/Controller.php",
+          "wp-content/plugins/woocommerce/src/Internal/Traits/RestApiCache.php",
+          "wp-content/plugins/woocommerce/src/StoreApi/RoutesController.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/api/class-wc-rest-subscriptions-controller.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 22749,
+        "lines": 327,
+        "sha256": "da17c4354403a69a95398def9172b7550c1e8df2ef46dc6e3b53c641a0380b35"
+      }
+    },
+    {
+      "slug": "wc-shipping-method",
+      "name": "wc-shipping-method",
+      "domain": "woocommerce",
+      "description": "Registers a custom WooCommerce shipping method with explicit control over which fields appear in the per-zone settings modal — extend WC_Shipping_Method, declare your fields in init_form_fields (and ONLY those fields, no unset / DOM hacks / CSS hides), set the $supports array to control whether the modal opens (omit 'instance-settings' to suppress it entirely), register via the woocommerce_shipping_methods filter, load the class on woocommerce_shipping_init. Corrects the \"this is React, removing fields is hard\" misconception — the zone-method modal is Backbone with a PHP-rendered settings_html string; the field list is wholly PHP-controlled. Use when scaffolding a shipping method or when you want a feature-flag-only modal without WC defaults. Triggers on WC_Shipping_Method, woocommerce_shipping_methods, woocommerce_shipping_init, init_form_fields with shipping context, $supports shipping-zones, calculate_shipping, add_rate, or \"remove default fields from shipping method\".",
+      "path": "woocommerce/wc-shipping-method",
+      "skill_path": "woocommerce/wc-shipping-method/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-shipping-method/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-shipping-method/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wc-shipping-method/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wc-shipping-method",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce",
+        "plugin-version-tested": "10.x",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://woocommerce.com/document/shipping-method-api/",
+          "https://github.com/woocommerce/woocommerce"
+        ],
+        "source-refs": [
+          "wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-shipping-method.php",
+          "wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-shipping.php",
+          "wp-content/plugins/woocommerce/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php",
+          "wp-content/plugins/woocommerce/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php",
+          "wp-content/plugins/woocommerce/assets/js/admin/wc-shipping-zone-methods.js"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 17846,
+        "lines": 349,
+        "sha256": "51303955edaf149e0412b31d9f2396ed9749cfbd4951c527c64c33916b95d88b"
+      }
+    },
+    {
+      "slug": "wc-shipping-providers",
+      "name": "wc-shipping-providers",
+      "domain": "woocommerce",
+      "description": "Register a custom WooCommerce shipping provider — extend AbstractShippingProvider and add it via the woocommerce_fulfillment_shipping_providers filter (WC 10.1+). Distinct from shipping methods (rate at checkout) — a provider is a carrier identity (UPS, FedEx, DHL, your custom carrier) used by the Fulfillments system for tracking URLs, tracking-number pattern detection, country-pair support, and the orders-list filter. Required methods get_key / get_name / get_icon / get_tracking_url, with optional shipping-from / shipping-to / try_parse_tracking_number. Registration accepts class names (resolved via the DI container) or pre-built instances, keyed by get_key. Use when integrating a private carrier, fulfillment service, or any tracking-aware shipping identity. Triggers on AbstractShippingProvider, woocommerce_fulfillment_shipping_providers, FulfillmentUtils::get_shipping_providers, \"shipping provider\" in WooCommerce context, or carrier tracking integration.",
+      "path": "woocommerce/wc-shipping-providers",
+      "skill_path": "woocommerce/wc-shipping-providers/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-shipping-providers/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-shipping-providers/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wc-shipping-providers/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wc-shipping-providers",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce",
+        "plugin-version-tested": "10.8.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-26",
+        "docs": [
+          "https://github.com/woocommerce/woocommerce"
+        ],
+        "source-refs": [
+          "wp-content/plugins/woocommerce/src/Admin/Features/Fulfillments/Providers/AbstractShippingProvider.php",
+          "wp-content/plugins/woocommerce/src/Admin/Features/Fulfillments/Providers/DHLShippingProvider.php",
+          "wp-content/plugins/woocommerce/src/Admin/Features/Fulfillments/Providers/UPSShippingProvider.php",
+          "wp-content/plugins/woocommerce/src/Admin/Features/Fulfillments/ShippingProviders.php",
+          "wp-content/plugins/woocommerce/src/Admin/Features/Fulfillments/FulfillmentUtils.php",
+          "wp-content/plugins/woocommerce/src/Admin/Features/Fulfillments/FulfillmentsManager.php",
+          "wp-content/plugins/woocommerce/src/Internal/RestApi/Routes/V4/Fulfillments/Controller.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 17861,
+        "lines": 333,
+        "sha256": "fcb9b2e37dba62fe2a026db527b14400820e0593f3ceb61e7d50acaa56018183"
+      }
+    },
+    {
+      "slug": "wc-store-api",
+      "name": "wc-store-api",
+      "domain": "woocommerce",
+      "description": "Build against the WooCommerce Store API (`/wp-json/wc/store/v1`) for shopper-facing products, cart, checkout, Cart/Checkout Blocks, and headless carts. Covers route choice, Nonce header (`wp_create_nonce('wc_store_api')`) vs Cart-Token, Store API sessions/CORS/rate limits, `woocommerce_store_api_register_endpoint_data`, `/cart/extensions` + `extensionCartUpdate`, payment requirements, product query pitfalls such as `related`, and when to use WC REST `wc/v4` instead. Use when adding checkout-block data, Store API calls, custom cart state, Store API payment availability, or headless cart/checkout behavior.",
+      "path": "woocommerce/wc-store-api",
+      "skill_path": "woocommerce/wc-store-api/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-store-api/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-store-api/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wc-store-api/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wc-store-api",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce",
+        "plugin-version-tested": "10.8.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-26",
+        "docs": [
+          "https://developer.woocommerce.com/docs/apis/store-api/",
+          "https://developer.woocommerce.com/docs/apis/store-api/nonce-tokens/",
+          "https://developer.woocommerce.com/docs/apis/store-api/cart-tokens/",
+          "https://developer.woocommerce.com/docs/apis/store-api/extending-store-api/extend-store-api-add-data/"
+        ],
+        "source-refs": [
+          "wp-content/plugins/woocommerce/src/StoreApi/RoutesController.php",
+          "wp-content/plugins/woocommerce/src/StoreApi/Routes/V1/AbstractCartRoute.php",
+          "wp-content/plugins/woocommerce/src/StoreApi/Authentication.php",
+          "wp-content/plugins/woocommerce/src/StoreApi/Schemas/ExtendSchema.php",
+          "wp-content/plugins/woocommerce/src/StoreApi/functions.php",
+          "wp-content/plugins/woocommerce/src/StoreApi/Routes/V1/CartExtensions.php",
+          "wp-content/plugins/woocommerce/src/StoreApi/Schemas/V1/CartExtensionsSchema.php",
+          "wp-content/plugins/woocommerce/src/StoreApi/Utilities/CartController.php",
+          "wp-content/plugins/woocommerce/src/StoreApi/Utilities/ProductQuery.php",
+          "wp-content/plugins/woocommerce/src/StoreApi/Routes/V1/Products.php",
+          "wp-content/plugins/woocommerce/assets/client/blocks/wc-blocks-data.js"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 16699,
+        "lines": 295,
+        "sha256": "45a4bfbf07c3edec27bef711d1a295ea010909e434da83de563fe6af59a7c8fe"
+      }
+    },
+    {
+      "slug": "wc-stripe-add-payment-method",
+      "name": "wc-stripe-add-payment-method",
+      "domain": "woocommerce",
+      "description": "WooCommerce Stripe Gateway skill for the fragile My Account payment-methods and add-payment-method flows. Use when editing or replacing Woo account templates, payment-methods.php, form-add-payment-method.php, Stripe card/token UI, saved cards, SetupIntent, Payment Element/UPE, billing details, WC payment tokens, customer account payment-method endpoints, Subscriptions change-payment-method compatibility, or code contains add_payment_method, add-payment-method, form#add_payment_method, payment_method_stripe, wc-stripe-upe-element, wc-stripe-setup-intent, stripe_source, wc_stripe_create_setup_intent, wc_stripe_upe_params, wc-stripe-payment-method, or woocommerce-gateway-stripe.",
+      "path": "woocommerce/wc-stripe-add-payment-method",
+      "skill_path": "woocommerce/wc-stripe-add-payment-method/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-stripe-add-payment-method/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-stripe-add-payment-method/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wc-stripe-add-payment-method/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wc-stripe-add-payment-method",
+      "metadata": {
+        "author": "Soczo Kristof",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce-gateway-stripe",
+        "plugin-version-tested": "10.6.1",
+        "woocommerce-version-tested": "10.7",
+        "php-min": "7.4",
+        "last-updated": "2026-05-01",
+        "source-refs": [
+          "wp-content/plugins/woocommerce/templates/myaccount/payment-methods.php",
+          "wp-content/plugins/woocommerce/templates/myaccount/form-add-payment-method.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-form-handler.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-frontend-scripts.php",
+          "wp-content/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php",
+          "wp-content/plugins/woocommerce/assets/js/frontend/add-payment-method.js",
+          "wp-content/plugins/woocommerce-gateway-stripe/woocommerce-gateway-stripe.php",
+          "wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php",
+          "wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method.php",
+          "wp-content/plugins/woocommerce-gateway-stripe/includes/class-wc-stripe-intent-controller.php",
+          "wp-content/plugins/woocommerce-gateway-stripe/includes/abstracts/abstract-wc-stripe-payment-gateway.php",
+          "wp-content/plugins/woocommerce-gateway-stripe/assets/js/stripe.js",
+          "wp-content/plugins/woocommerce-gateway-stripe/build/upe-classic.js",
+          "wp-content/plugins/woocommerce-gateway-stripe/includes/payment-tokens/class-wc-stripe-payment-tokens.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-payment-tokens.php",
+          "wp-content/plugins/woocommerce/includes/data-stores/class-wc-payment-token-data-store.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/class-wc-subscriptions-change-payment-gateway.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 21170,
+        "lines": 383,
+        "sha256": "6b5ae4cf4484ef1a46254f4277af22e11ddf96fc2e7b75514d487915b2f3de2d"
+      }
+    },
+    {
+      "slug": "wc-variations-data",
+      "name": "wc-variations-data",
+      "domain": "woocommerce",
+      "description": "Read, query, and write WooCommerce product variations correctly — the WC_Product_Variable (parent) vs WC_Product_Variation (child) class split, the parent's get_variation_prices( $for_display ) cached aggregation and how to bust the wc_var_prices_<id> transient, programmatic variation creation via WC_Product_Variation + set_parent_id + set_attributes + save followed by WC_Product_Variable::sync, the inherited-vs-own variation stock model (parent flag, variation flag, derived stock_status), get_available_variations for frontend variation data, and the $for_display tax-handling parameter that breaks display logic when forgotten. Use when scaffolding plugin code that creates / queries / modifies variations or when debugging stale variation data after programmatic writes. Triggers on WC_Product_Variation, WC_Product_Variable, get_variation_prices, get_available_variations, product_variation post type, wc_var_prices, sync_variation, or programmatic variation creation context.",
+      "path": "woocommerce/wc-variations-data",
+      "skill_path": "woocommerce/wc-variations-data/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-variations-data/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-variations-data/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wc-variations-data/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wc-variations-data",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce",
+        "plugin-version-tested": "10.x",
+        "php-min": "7.4",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://github.com/woocommerce/woocommerce/wiki/Product-Variations",
+          "https://woocommerce.com/document/managing-product-variations/"
+        ],
+        "source-refs": [
+          "wp-content/plugins/woocommerce/includes/class-wc-product-variable.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-product-variation.php",
+          "wp-content/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php",
+          "wp-content/plugins/woocommerce/includes/data-stores/class-wc-product-variation-data-store-cpt.php",
+          "wp-content/plugins/woocommerce/includes/wc-product-functions.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 18243,
+        "lines": 319,
+        "sha256": "96d8bd368ef2deb7b825925ac0febec2ca6b1d4ddf5866f29b2154f8b3b70e70"
+      }
+    },
+    {
+      "slug": "wc-variations-pricing-filters",
+      "name": "wc-variations-pricing-filters",
+      "domain": "woocommerce",
+      "description": "Mutate WooCommerce variation prices via filters — pick the right layer (woocommerce_product_get_price for simple/non-variation products, woocommerce_product_variation_get_price for variations, the woocommerce_variation_prices_* family for the parent min/max aggregation that feeds the catalog \"From X to Y\" range), and the critical step of filtering woocommerce_get_variation_prices_hash whenever your price logic depends on context outside the default cache key (user role, custom toggle, time of day) — otherwise one user's filtered price gets cached and served to everyone. Use for role-based pricing, time-based discounts, or \"filter variation prices but the min/max range doesn't update\" debugging. Triggers on woocommerce_product_get_price, woocommerce_product_variation_get_price, woocommerce_variation_prices_*, woocommerce_get_variation_prices_hash, wc_var_prices.",
+      "path": "woocommerce/wc-variations-pricing-filters",
+      "skill_path": "woocommerce/wc-variations-pricing-filters/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-variations-pricing-filters/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wc-variations-pricing-filters/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wc-variations-pricing-filters/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wc-variations-pricing-filters",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce",
+        "plugin-version-tested": "10.x",
+        "php-min": "7.4",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://woocommerce.com/document/woocommerce-pricing-functions/",
+          "https://github.com/woocommerce/woocommerce/wiki/Product-Variations"
+        ],
+        "source-refs": [
+          "wp-content/plugins/woocommerce/includes/class-wc-product-variable.php",
+          "wp-content/plugins/woocommerce/includes/class-wc-product-variation.php",
+          "wp-content/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php",
+          "wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-product.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 19489,
+        "lines": 306,
+        "sha256": "185a829307f033082f9544be222cb71bcd28cfa119742cb784b4fdd65b324a8e"
+      }
+    },
+    {
+      "slug": "wcm-access-discounts",
+      "name": "wcm-access-discounts",
+      "domain": "woocommerce",
+      "description": "WooCommerce Memberships access, restriction, drip-content, product-grant, and member-discount playbook. Use when code checks whether a user can view/purchase content or products, changes scheduled access dates, customizes protected/public content, maps parent or variation products that grant membership access, applies member prices, reads original prices around discounts, or contains wc_memberships_user_can, wc_memberships_access_from_time, wc_memberships_user_has_member_discount, wc_memberships_get_member_product_discount, wc_memberships_get_discounted_price, or member discount badge hooks.",
+      "path": "woocommerce/wcm-access-discounts",
+      "skill_path": "woocommerce/wcm-access-discounts/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wcm-access-discounts/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wcm-access-discounts/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wcm-access-discounts/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wcm-access-discounts",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce-memberships",
+        "plugin-version-tested": "1.28.1",
+        "php-min": "7.4",
+        "last-updated": "2026-04-29",
+        "source-refs": [
+          "wp-content/plugins/woocommerce-memberships/src/class-wc-memberships-capabilities.php",
+          "wp-content/plugins/woocommerce-memberships/src/Restrictions.php",
+          "wp-content/plugins/woocommerce-memberships/src/Restrictions/Posts.php",
+          "wp-content/plugins/woocommerce-memberships/src/Restrictions/Products.php",
+          "wp-content/plugins/woocommerce-memberships/src/class-wc-memberships-member-discounts.php",
+          "wp-content/plugins/woocommerce-memberships/src/functions/wc-memberships-functions-restrictions.php",
+          "wp-content/plugins/woocommerce-memberships/src/functions/wc-memberships-functions-member-discounts.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 13297,
+        "lines": 195,
+        "sha256": "a91d66950f874841a837934a1920dcec0e1d06807270b0f0667196dc8ed6e12a"
+      }
+    },
+    {
+      "slug": "wcm-data-model-subscriptions-link",
+      "name": "wcm-data-model-subscriptions-link",
+      "domain": "woocommerce",
+      "description": "WooCommerce Memberships storage and relationship map for membership plan CPTs, user membership CPTs, post statuses, plan/user membership meta keys, rule storage, profile-field storage, order grant meta, and WooCommerce Subscriptions-linked memberships. Use when code reads or writes wc_membership_plan, wc_user_membership, wcm-* statuses, wc_memberships_rules, _subscription_id, _has_installment_plan, _free_trial_end_date, membership plan access meta, user membership dates, product/order grant meta, or when an agent needs exact Memberships CPT/meta names and the Memberships-Subscriptions relation.",
+      "path": "woocommerce/wcm-data-model-subscriptions-link",
+      "skill_path": "woocommerce/wcm-data-model-subscriptions-link/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wcm-data-model-subscriptions-link/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wcm-data-model-subscriptions-link/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wcm-data-model-subscriptions-link/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wcm-data-model-subscriptions-link",
+      "metadata": {
+        "author": "Soczo Kristof",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce-memberships",
+        "plugin-version-tested": "1.28.1",
+        "php-min": "7.4",
+        "last-updated": "2026-05-01",
+        "source-refs": [
+          "wp-content/plugins/woocommerce-memberships/src/class-wc-memberships-post-types.php",
+          "wp-content/plugins/woocommerce-memberships/src/class-wc-memberships-membership-plan.php",
+          "wp-content/plugins/woocommerce-memberships/src/class-wc-memberships-user-membership.php",
+          "wp-content/plugins/woocommerce-memberships/src/class-wc-memberships-rules.php",
+          "wp-content/plugins/woocommerce-memberships/src/functions/wc-memberships-functions-orders.php",
+          "wp-content/plugins/woocommerce-memberships/src/Data_Stores/Profile_Field/User_Meta.php",
+          "wp-content/plugins/woocommerce-memberships/src/Data_Stores/Profile_Field_Definition/Option.php",
+          "wp-content/plugins/woocommerce-memberships/src/integrations/subscriptions/class-wc-memberships-integration-subscriptions-user-membership.php",
+          "wp-content/plugins/woocommerce-memberships/src/integrations/subscriptions/class-wc-memberships-integration-subscriptions.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 11395,
+        "lines": 204,
+        "sha256": "f51ec97763d41fae05b5c95e061fde95f7aab638988ef16cefcc468660945d56"
+      }
+    },
+    {
+      "slug": "wcm-membership-hooks",
+      "name": "wcm-membership-hooks",
+      "domain": "woocommerce",
+      "description": "Curated WooCommerce Memberships hook and extension-point map for plugins that build on user memberships, membership plans, status transitions, purchase/free-signup grants, profile fields, REST API, webhooks, members-area templates, CSV import/export, and Woo Subscriptions-linked memberships. Use when the user asks for a Memberships hook list, \"where should I hook\", membership created/saved, status changed, grant access from order, user membership API, profile fields, member directory, or code contains wc_memberships_, WC_Memberships_User_Membership, WC_Memberships_Membership_Plan, wc_user_membership, wc_membership_plan, wcm-, _subscription_id, wc_memberships_rules, or woocommerce-memberships.",
+      "path": "woocommerce/wcm-membership-hooks",
+      "skill_path": "woocommerce/wcm-membership-hooks/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wcm-membership-hooks/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wcm-membership-hooks/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wcm-membership-hooks/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wcm-membership-hooks",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce-memberships",
+        "plugin-version-tested": "1.28.1",
+        "php-min": "7.4",
+        "last-updated": "2026-05-10",
+        "source-refs": [
+          "wp-content/plugins/woocommerce-memberships/src/class-wc-memberships-post-types.php",
+          "wp-content/plugins/woocommerce-memberships/src/class-wc-memberships-user-memberships.php",
+          "wp-content/plugins/woocommerce-memberships/src/class-wc-memberships-user-membership.php",
+          "wp-content/plugins/woocommerce-memberships/src/class-wc-memberships-membership-plan.php",
+          "wp-content/plugins/woocommerce-memberships/src/class-wc-memberships-rules.php",
+          "wp-content/plugins/woocommerce-memberships/src/API/Controller/User_Memberships.php",
+          "wp-content/plugins/woocommerce-memberships/src/API/Webhooks.php",
+          "wp-content/plugins/woocommerce-memberships/src/Profile_Fields.php",
+          "wp-content/plugins/woocommerce-memberships/src/integrations/subscriptions/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 22922,
+        "lines": 266,
+        "sha256": "12021bbf6d5e63b2bd9427e373cdd352c1c443e9d59a886df3eaa3d8999ca656"
+      }
+    },
+    {
+      "slug": "wcs-data-model-switching-gifting",
+      "name": "wcs-data-model-switching-gifting",
+      "domain": "woocommerce",
+      "description": "WooCommerce Subscriptions data model, switcher, and gifting reference for exact order type names, product type slugs, subscription meta keys, schedule/date keys, related-order relation meta, switch cart data, switch order data, switched item types/meta, proration hooks, and WCS Gifting recipient storage. Use when code reads or writes shop_subscription, subscription, variable-subscription, subscription_variation, _billing_period, _schedule_next_payment, _subscription_switch_data, _subscription_switch, subscription_switch, _switched_subscription_item_id, wcsg_gift_recipients_email, _recipient_user, _recipient_user_email_address, wcsg_recipient, or when an agent needs the full WooCommerce Subscriptions switcher/gifting flow.",
+      "path": "woocommerce/wcs-data-model-switching-gifting",
+      "skill_path": "woocommerce/wcs-data-model-switching-gifting/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wcs-data-model-switching-gifting/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wcs-data-model-switching-gifting/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wcs-data-model-switching-gifting/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wcs-data-model-switching-gifting",
+      "metadata": {
+        "author": "Soczo Kristof",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce-subscriptions",
+        "plugin-version-tested": "8.6.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-01",
+        "source-refs": [
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/class-wc-subscriptions-core-plugin.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/class-wc-subscription.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/data-stores/class-wcs-subscription-data-store-cpt.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/data-stores/class-wcs-orders-table-subscription-data-store.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/class-wc-subscriptions-product.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/wcs-functions.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/wcs-switch-functions.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/switching/class-wc-subscriptions-switcher.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/switching/class-wcs-switch-totals-calculator.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/gifting/class-wcs-gifting.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/gifting/class-wcsg-product.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/gifting/class-wcsg-cart.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/gifting/class-wcsg-checkout.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/gifting/class-wcsg-recipient-management.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 18463,
+        "lines": 305,
+        "sha256": "94a25622384f134f78cbf90538735a871a230c3319898abbadbaa9790985eb2d"
+      }
+    },
+    {
+      "slug": "wcs-renewal-scheduler",
+      "name": "wcs-renewal-scheduler",
+      "domain": "woocommerce",
+      "description": "Safely integrate with WooCommerce Subscriptions renewal, next-payment scheduling, Action Scheduler events, and retry flow. Shows when to use WC_Subscription::update_dates, update_status, wcs_create_renewal_order, wcs_renewal_order_created, woocommerce_scheduled_subscription_payment, woocommerce_scheduled_subscription_payment_{gateway_id}, woocommerce_subscription_renewal_payment_complete, and payment retry hooks. Use when changing next payment dates, forcing/rescheduling renewals, reacting to failed renewals, building gateway recurring charge logic, or debugging missing/duplicate renewal orders.",
+      "path": "woocommerce/wcs-renewal-scheduler",
+      "skill_path": "woocommerce/wcs-renewal-scheduler/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wcs-renewal-scheduler/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wcs-renewal-scheduler/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wcs-renewal-scheduler/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wcs-renewal-scheduler",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce-subscriptions",
+        "plugin-version-tested": "8.6.0",
+        "php-min": "7.4",
+        "last-updated": "2026-04-29",
+        "source-refs": [
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/class-wcs-action-scheduler.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/abstracts/abstract-wcs-scheduler.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/class-wc-subscriptions-manager.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/gateways/class-wc-subscriptions-payment-gateways.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/payment-retry/class-wcs-retry-manager.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 12281,
+        "lines": 245,
+        "sha256": "337774883c1755e5eb9a115f147e7d9f9104ec09f9290447c690dcf03dec13b7"
+      }
+    },
+    {
+      "slug": "wcs-subscription-hooks",
+      "name": "wcs-subscription-hooks",
+      "domain": "woocommerce",
+      "description": "Curated WooCommerce Subscriptions hook and extension-point map for choosing the right action/filter around WC_Subscription creation, status transitions, date changes, renewal orders, scheduled payments, payment retries, gateway events, switching, gifting, related orders, REST/API responses, and account/admin UI. Use when the user asks for a Woo Subscriptions hook list, \"where should I hook\", \"after renewal\", \"subscription status changed\", or when code contains WC_Subscription, wcs_create_subscription, wcs_create_renewal_order, woocommerce_scheduled_subscription_payment, wcs_renewal_order_created, payment_retry, wcs_get_subscriptions, wcsg_, subscription_switch, _subscription_switch_data, _recipient_user, wcsg_recipient, or subscription switching.",
+      "path": "woocommerce/wcs-subscription-hooks",
+      "skill_path": "woocommerce/wcs-subscription-hooks/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wcs-subscription-hooks/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/woocommerce/wcs-subscription-hooks/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/woocommerce/wcs-subscription-hooks/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/woocommerce/wcs-subscription-hooks",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "woocommerce-subscriptions",
+        "plugin-version-tested": "8.6.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-01",
+        "source-refs": [
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/wcs-functions.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/class-wc-subscription.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/class-wc-subscriptions-change-payment-gateway.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/class-wc-subscriptions-core-plugin.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/class-wc-subscriptions-product.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/wcs-renewal-functions.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/core/class-wcs-action-scheduler.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/payment-retry/class-wcs-retry-manager.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/switching/class-wc-subscriptions-switcher.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/switching/class-wcs-cart-switch.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/gifting/class-wcs-gifting.php",
+          "wp-content/plugins/woocommerce-subscriptions/includes/gifting/class-wcsg-checkout.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 19991,
+        "lines": 224,
+        "sha256": "523ace7614a10adc72425250a897c14536682fa1d5bd5f154881f5c8156f1f85"
+      }
+    },
+    {
+      "slug": "wp-abilities-api",
+      "name": "wp-abilities-api",
+      "domain": "wordpress",
+      "description": "Register WordPress Abilities: machine-readable plugin operations with JSON Schema contracts, required permission callbacks, optional REST exposure, client-side abilities, and AI/MCP-friendly discovery. Covers categories, wp_register_ability, WP_Ability::execute, REST run endpoints, @wordpress/abilities, @wordpress/core-abilities, meta.show_in_rest, annotations, and Ability vs REST route vs custom hook decisions. Use when exposing plugin functionality to agents, admin JS, external tools, WP AI Client workflows, or reviewing AI integration code.",
+      "path": "wordpress/wp-abilities-api",
+      "skill_path": "wordpress/wp-abilities-api/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-abilities-api/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-abilities-api/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-abilities-api/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-abilities-api",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.9 - 7.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-21",
+        "docs": [
+          "https://developer.wordpress.org/apis/abilities-api/",
+          "https://developer.wordpress.org/news/2025/11/introducing-the-wordpress-abilities-api/",
+          "https://make.wordpress.org/core/2026/03/24/client-side-abilities-api-in-wordpress-7-0/",
+          "https://packagist.org/packages/wordpress/abilities-api",
+          "https://github.com/WordPress/abilities-api"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 22255,
+        "lines": 416,
+        "sha256": "418f870b478623c47ff2a7a5f47e08ec6bbb3e5742bcbc49519594e1a4a4f392"
+      }
+    },
+    {
+      "slug": "wp-admin-codemirror",
+      "name": "wp-admin-codemirror",
+      "domain": "wordpress",
+      "description": "Embed WordPress's bundled CodeMirror editor in admin pages via `wp_enqueue_code_editor()` and `wp.codeEditor.initialize()`. Covers MIME / file mode selection for CSS, JS, JSON, HTML, PHP, SQL, Markdown, and YAML; the `false` return when user profile syntax highlighting is disabled; passing settings to JS; the bare textarea ID requirement for `initialize( 'mytextarea', settings )`; reading values with `instance.codemirror.getValue()`; `wp_code_editor_settings`; and linter handles such as `csslint`, `htmlhint`, `htmlhint-kses`, and `jsonlint`. Use for custom CSS, snippets, JSON schemas, webhook previews, regex fields, or any plugin settings textarea that needs syntax highlighting.",
+      "path": "wordpress/wp-admin-codemirror",
+      "skill_path": "wordpress/wp-admin-codemirror/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-admin-codemirror/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-admin-codemirror/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-admin-codemirror/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-admin-codemirror",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.0 - 7.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-24",
+        "docs": [
+          "https://developer.wordpress.org/reference/functions/wp_enqueue_code_editor/",
+          "https://developer.wordpress.org/reference/functions/wp_get_code_editor_settings/",
+          "https://developer.wordpress.org/reference/hooks/wp_code_editor_settings/",
+          "https://codemirror.net/5/doc/manual.html"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 13634,
+        "lines": 293,
+        "sha256": "600aaf1e84414b03b6ba93a7ed5f6d3019d6f3a4a630a1f978f72a63fd8f7d13"
+      }
+    },
+    {
+      "slug": "wp-admin-drag-and-drop",
+      "name": "wp-admin-drag-and-drop",
+      "domain": "wordpress",
+      "description": "Build WordPress admin drag-and-drop UI with core's bundled jQuery UI Sortable, Draggable, Droppable, optional `jquery-touch-punch`, `wp-api-fetch`, and `wp-a11y.speak()`. Covers flat reorder lists, connected lists / kanban columns, palette-to-dropzone clones, hierarchical tree indentation, REST order persistence, and keyboard reorder controls. Use when plugin admin pages need repeater row order, builder blocks, rule priority, kanban moves, custom field arrangers, pricing tiers, taxonomy term sort, or any non-React draggable admin UI.",
+      "path": "wordpress/wp-admin-drag-and-drop",
+      "skill_path": "wordpress/wp-admin-drag-and-drop/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-admin-drag-and-drop/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-admin-drag-and-drop/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-admin-drag-and-drop/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-admin-drag-and-drop",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.0 - 7.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-24",
+        "docs": [
+          "https://api.jqueryui.com/sortable/",
+          "https://api.jqueryui.com/draggable/",
+          "https://api.jqueryui.com/droppable/"
+        ]
+      },
+      "resources": [
+        {
+          "path": "reference.md",
+          "repo_path": "wordpress/wp-admin-drag-and-drop/reference.md",
+          "type": "reference",
+          "bytes": 5210,
+          "sha256": "828722fb087a64c1807320ae6d812ab21ce9247ae43a784622ff839e53265e5c"
+        }
+      ],
+      "has_reference": true,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 16477,
+        "lines": 291,
+        "sha256": "239c15b8192876d0cfd41d51980893f250755c9d55f03a671900fa3cab7f2336"
+      }
+    },
+    {
+      "slug": "wp-admin-form-controls",
+      "name": "wp-admin-form-controls",
+      "domain": "wordpress",
+      "description": "Use WordPress admin form-control widgets that ship in core, `wp-color-picker`, `jquery-ui-datepicker`, `jquery-ui-autocomplete`, and `wp-pointer`. Covers correct script/style enqueues, the missing jQuery UI datepicker CSS, `wpColorPicker` change / clear callbacks, datepicker `yy-mm-dd` formatting plus strict server sanitization, autocomplete `source` shapes with `response()`, core user/tag suggest, and `wp-pointer` dismissal through `dismiss-wp-pointer`. Use when adding color, date, typeahead, or first-run pointer controls to settings pages, metaboxes, or repeater rows.",
+      "path": "wordpress/wp-admin-form-controls",
+      "skill_path": "wordpress/wp-admin-form-controls/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-admin-form-controls/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-admin-form-controls/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-admin-form-controls/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-admin-form-controls",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.0 - 7.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-24",
+        "docs": [
+          "https://developer.wordpress.org/reference/functions/wp_enqueue_script/",
+          "https://api.jqueryui.com/datepicker/",
+          "https://api.jqueryui.com/autocomplete/",
+          "https://automattic.github.io/Iris/"
+        ]
+      },
+      "resources": [
+        {
+          "path": "reference.md",
+          "repo_path": "wordpress/wp-admin-form-controls/reference.md",
+          "type": "reference",
+          "bytes": 3928,
+          "sha256": "500a4b64df3d7fb96b03b455f045a2d428cf36022b5ef698ad99bd537d5e7906"
+        }
+      ],
+      "has_reference": true,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 12974,
+        "lines": 278,
+        "sha256": "8d8979c3d9e40d2c43000615441531435526b3541e31748ea8242b747a019d77"
+      }
+    },
+    {
+      "slug": "wp-admin-list-table",
+      "name": "wp-admin-list-table",
+      "domain": "wordpress",
+      "description": "Build WordPress admin tables by extending `WP_List_Table`. Covers the required `require_once`, constructor `singular` / `plural` / `ajax` args, `prepare_items()`, `get_columns()`, `column_cb()`, `column_default()`, `get_sortable_columns()`, `get_bulk_actions()`, `process_bulk_action()`, `extra_tablenav()`, pagination with `set_pagination_args()`, row actions, search, views, Screen Options per-page settings, sortable `orderby` / `order`, and the plugin CSRF gap, calling `check_admin_referer( 'bulk-' . $this->_args['plural'] )` before acting on `current_action()`. Use for license keys, jobs, logs, audit records, subscriptions, or any plugin record list needing WP-native UI.",
+      "path": "wordpress/wp-admin-list-table",
+      "skill_path": "wordpress/wp-admin-list-table/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-admin-list-table/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-admin-list-table/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-admin-list-table/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-admin-list-table",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.0 - 7.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-24",
+        "docs": [
+          "https://developer.wordpress.org/reference/classes/wp_list_table/",
+          "https://developer.wordpress.org/reference/functions/add_screen_option/",
+          "https://developer.wordpress.org/reference/functions/check_admin_referer/"
+        ]
+      },
+      "resources": [
+        {
+          "path": "reference.md",
+          "repo_path": "wordpress/wp-admin-list-table/reference.md",
+          "type": "reference",
+          "bytes": 7336,
+          "sha256": "47ddb255b64a630022e8a1a118500c7de874161709e8aa31be14472c47cad3d4"
+        }
+      ],
+      "has_reference": true,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 14270,
+        "lines": 250,
+        "sha256": "9db4d93d71520daf45e788c50670f6a16946057ec58b3324eca15a95d4b10fed"
+      }
+    },
+    {
+      "slug": "wp-admin-media-frame",
+      "name": "wp-admin-media-frame",
+      "domain": "wordpress",
+      "description": "Open the standard WordPress Media Library picker from plugin admin UI with `wp_enqueue_media()` and `wp.media()`. Covers the screen-gated enqueue, `media-editor` dependency, `wp.media( { frame, title, button, library, multiple } )`, `library` filters for type / MIME / uploadedTo / author, `multiple` values `true` and `'add'`, `select` and `open` events, `frame.state().get( 'selection' ).first().toJSON()`, attachment `sizes`, frame caching, pre-selecting existing attachments, and saving attachment IDs instead of URLs. Use for image, file, gallery, logo, avatar, cover, or per-row icon pickers in settings pages, metaboxes, and repeaters.",
+      "path": "wordpress/wp-admin-media-frame",
+      "skill_path": "wordpress/wp-admin-media-frame/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-admin-media-frame/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-admin-media-frame/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-admin-media-frame/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-admin-media-frame",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.0 - 7.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-24",
+        "docs": [
+          "https://developer.wordpress.org/reference/functions/wp_enqueue_media/",
+          "https://developer.wordpress.org/reference/functions/wp_prepare_attachment_for_js/",
+          "https://codex.wordpress.org/Javascript_Reference/wp.media"
+        ]
+      },
+      "resources": [
+        {
+          "path": "reference.md",
+          "repo_path": "wordpress/wp-admin-media-frame/reference.md",
+          "type": "reference",
+          "bytes": 4397,
+          "sha256": "81c3a0dcbbd554fb032893deed21d0bb7f786aa7843ca8479c93691b80229395"
+        }
+      ],
+      "has_reference": true,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 13936,
+        "lines": 282,
+        "sha256": "3d4d43ff105d81e221478e1518bcce893953b15b16e7901bb8769d8c69832558"
+      }
+    },
+    {
+      "slug": "wp-admin-notices",
+      "name": "wp-admin-notices",
+      "domain": "wordpress",
+      "description": "Render WordPress admin notices via the four core hooks (`admin_notices`, `network_admin_notices`, `user_admin_notices`, `all_admin_notices`) and the 6.4+ `wp_admin_notice()` / `wp_get_admin_notice()` helpers. Covers the four severity classes (`notice-error/-warning/-info/-success`), `is-dismissible`, per-user persisted dismissal via `user_meta` + REST endpoint, screen targeting via `get_current_screen()`, transient-backed flash notices after redirects, and the `wp_admin_notice_args` / `wp_admin_notice_markup` filters. Use for onboarding banners, post-save flashes, integration warnings, version-bump tours, or config nags.",
+      "path": "wordpress/wp-admin-notices",
+      "skill_path": "wordpress/wp-admin-notices/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-admin-notices/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-admin-notices/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-admin-notices/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-admin-notices",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.4 - 7.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-24",
+        "docs": [
+          "https://developer.wordpress.org/reference/functions/wp_admin_notice/",
+          "https://developer.wordpress.org/reference/functions/wp_get_admin_notice/",
+          "https://developer.wordpress.org/reference/hooks/admin_notices/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 13602,
+        "lines": 266,
+        "sha256": "f95e9ee9bdc72ba3bc67ecb5eaa16ff48c937d8d5306e351271a356ee42fd949"
+      }
+    },
+    {
+      "slug": "wp-admin-postbox-sortable",
+      "name": "wp-admin-postbox-sortable",
+      "domain": "wordpress",
+      "description": "Wire up WordPress postboxes on custom plugin admin pages with collapse, drag sorting, Screen Options visibility, and core persistence. Covers `add_meta_box()`, `do_meta_boxes()`, the `postbox` script, `postboxes.add_postbox_toggles( pageId )`, the `.meta-box-sortables` / `.postbox` / `.hndle` DOM contract, and the two nonce fields plugins forget, `closedpostboxesnonce` and `meta-box-order-nonce`. Use when adding collapsible admin boxes, draggable metabox layouts, or Screen Options show/hide behavior to a custom plugin admin screen; use raw `jquery-ui-sortable` instead for non-postbox repeater rows.",
+      "path": "wordpress/wp-admin-postbox-sortable",
+      "skill_path": "wordpress/wp-admin-postbox-sortable/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-admin-postbox-sortable/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-admin-postbox-sortable/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-admin-postbox-sortable/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-admin-postbox-sortable",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.0 - 7.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-24",
+        "docs": [
+          "https://developer.wordpress.org/reference/functions/add_meta_box/",
+          "https://developer.wordpress.org/reference/functions/do_meta_boxes/",
+          "https://developer.wordpress.org/reference/functions/wp_nonce_field/",
+          "https://api.jqueryui.com/sortable/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 14415,
+        "lines": 273,
+        "sha256": "44c9008f091c119b5df2495198b1f677bed744400e460634b7568a03631218bd"
+      }
+    },
+    {
+      "slug": "wp-admin-settings-api",
+      "name": "wp-admin-settings-api",
+      "domain": "wordpress",
+      "description": "Build plugin admin settings pages with the WordPress Settings API instead of custom form handlers. Covers `register_setting()`, `add_settings_section()`, `add_settings_field()`, `settings_fields()`, `do_settings_sections()`, `add_settings_error()`, `settings_errors()`, `admin_init` registration, `<form method=\"post\" action=\"options.php\">`, `sanitize_callback`, `$option_group` vs `$page`, single-array option storage, tabbed pages, `show_in_rest` schemas, custom option capabilities via `option_page_capability_{$option_group}`, and the mistake of POSTing to your own handler. Use for plugin settings screens, integration config, feature toggles, or any options page that saves to `wp_options`.",
+      "path": "wordpress/wp-admin-settings-api",
+      "skill_path": "wordpress/wp-admin-settings-api/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-admin-settings-api/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-admin-settings-api/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-admin-settings-api/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-admin-settings-api",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.0 - 7.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-24",
+        "docs": [
+          "https://developer.wordpress.org/reference/functions/register_setting/",
+          "https://developer.wordpress.org/reference/functions/add_settings_section/",
+          "https://developer.wordpress.org/reference/functions/add_settings_field/",
+          "https://developer.wordpress.org/plugins/settings/settings-api/"
+        ]
+      },
+      "resources": [
+        {
+          "path": "reference.md",
+          "repo_path": "wordpress/wp-admin-settings-api/reference.md",
+          "type": "reference",
+          "bytes": 7250,
+          "sha256": "ff578ba7af3cda1a61a01b33e5479bc816d2f444080218cb557bad1f02dfe2b4"
+        }
+      ],
+      "has_reference": true,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 15602,
+        "lines": 268,
+        "sha256": "7078770be094e4462135ca118e740101a2982bf4f1c6acabd919a7bbf6f93ea4"
+      }
+    },
+    {
+      "slug": "wp-ai-client",
+      "name": "wp-ai-client",
+      "domain": "wordpress",
+      "description": "Build and review WordPress 7.0 WP AI Client integrations for provider-agnostic text, image, speech, video, JSON, and ability-powered generation. Covers wp_ai_client_prompt, WP_AI_Client_Prompt_Builder, wp_supports_ai, using_model_preference, is_supported_* checks, generate_* / generate_*_result methods, WP_Error handling, using_abilities, WP_AI_Client_Ability_Function_Resolver, connector-backed provider configuration, prompt prevention filters, and safe AI feature gating. Use when plugin code calls AI models or adds AI-powered WordPress features.",
+      "path": "wordpress/wp-ai-client",
+      "skill_path": "wordpress/wp-ai-client/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-ai-client/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-ai-client/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-ai-client/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-ai-client",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "7.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-21",
+        "docs": [
+          "https://make.wordpress.org/core/2026/03/24/introducing-the-ai-client-in-wordpress-7-0/",
+          "https://make.wordpress.org/core/2026/05/14/wordpress-7-0-field-guide/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 9247,
+        "lines": 230,
+        "sha256": "35b80320111c7e26cc309aac019ad5362acac8d34e2a4227b450f0e3ff75d1e0"
+      }
+    },
+    {
+      "slug": "wp-cli-extending",
+      "name": "wp-cli-extending",
+      "domain": "wordpress",
+      "description": "Add custom WP-CLI commands to a WordPress plugin via `WP_CLI::add_command( $name, $callable, $args )`. Covers the class-based command pattern with PHPDoc-driven synopsis, positional vs `--flag` args, I/O helpers (`success` / `log` / `warning` / `error` / `confirm` / `debug`), formatted output via `WP_CLI\\Utils\\format_items()` + `--format=table|csv|json|yaml|count`, progress bars with `WP_CLI\\Utils\\make_progress_bar()`, `WP_CLI::runcommand()` for invoking other commands, lifecycle hooks (`before_wp_load`, `before_invoke:<cmd>`, `after_invoke:<cmd>`), and the `defined( 'WP_CLI' ) && WP_CLI` registration guard. Use for plugin bulk import, data migration, queue dispatch, debug introspection, or any CLI surface.",
+      "path": "wordpress/wp-cli-extending",
+      "skill_path": "wordpress/wp-cli-extending/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-cli-extending/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-cli-extending/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-cli-extending/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-cli-extending",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "WP-CLI 2.10 - 2.11; WP 6.0 - 7.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-24",
+        "docs": [
+          "https://make.wordpress.org/cli/handbook/references/internal-api/wp-cli-add-command/",
+          "https://make.wordpress.org/cli/handbook/references/internal-api/",
+          "https://make.wordpress.org/cli/handbook/guides/commands-cookbook/",
+          "https://make.wordpress.org/cli/handbook/guides/hook-system/"
+        ]
+      },
+      "resources": [
+        {
+          "path": "reference.md",
+          "repo_path": "wordpress/wp-cli-extending/reference.md",
+          "type": "reference",
+          "bytes": 4427,
+          "sha256": "de7fa6b0ed7f426da29db0d0cf35a240783738fcdee332c2ce05315d7f50d280"
+        }
+      ],
+      "has_reference": true,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 12663,
+        "lines": 248,
+        "sha256": "1393bbbcd47e2aed60d07bac9c9920300be304a232dac0e5b6b0f8172c5df4a6"
+      }
+    },
+    {
+      "slug": "wp-connectors-api",
+      "name": "wp-connectors-api",
+      "domain": "wordpress",
+      "description": "Register and review WordPress 7.0 Connectors API integrations for external services, especially AI providers and API-key backed services shown under Settings > Connectors. Covers wp_connectors_init, WP_Connector_Registry, wp_get_connector, wp_get_connectors, wp_is_connector_registered, api_key vs none authentication, env/constant key priority, WP AI Client provider auto-discovery, connector settings, and safe metadata override patterns. Use when code mentions connectors, Settings > Connectors, external provider setup, or connector API keys.",
+      "path": "wordpress/wp-connectors-api",
+      "skill_path": "wordpress/wp-connectors-api/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-connectors-api/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-connectors-api/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-connectors-api/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-connectors-api",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "7.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-21",
+        "docs": [
+          "https://make.wordpress.org/core/2026/03/18/introducing-the-connectors-api-in-wordpress-7-0/",
+          "https://make.wordpress.org/core/2026/05/14/wordpress-7-0-field-guide/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 8851,
+        "lines": 196,
+        "sha256": "7df0f05f16643f21bc8828bdc0da23a0d8aa3cefd45af2e4195fb8a620ec0cd8"
+      }
+    },
+    {
+      "slug": "wp-filesystem-api",
+      "name": "wp-filesystem-api",
+      "domain": "wordpress",
+      "description": "Read, write, copy, delete, chmod files from a WordPress plugin via the `WP_Filesystem` abstraction instead of bare PHP. Covers the bootstrap (`require_once ABSPATH . 'wp-admin/includes/file.php'` → `request_filesystem_credentials()` → `WP_Filesystem()` → `$wp_filesystem->*` methods), the four transports (direct, ssh2, ftpext, ftpsockets) selected by `get_filesystem_method()`, the `FS_METHOD` / `FS_CHMOD_FILE` / `FS_CHMOD_DIR` constants, the credentials form flow, and when to use `wp_handle_upload()` / `wp_upload_dir()` instead. Use for plugin writes outside `wp-content/uploads`, generated CSS/cache files outside uploads, log output, bundled-asset extraction, and any FS op that must work on FTP-only shared hosts.",
+      "path": "wordpress/wp-filesystem-api",
+      "skill_path": "wordpress/wp-filesystem-api/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-filesystem-api/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-filesystem-api/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-filesystem-api/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-filesystem-api",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.0 - 7.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-24",
+        "docs": [
+          "https://developer.wordpress.org/reference/classes/wp_filesystem_base/",
+          "https://developer.wordpress.org/reference/functions/wp_filesystem/",
+          "https://developer.wordpress.org/reference/functions/request_filesystem_credentials/",
+          "https://developer.wordpress.org/advanced-administration/wordpress/wp-config/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 14265,
+        "lines": 284,
+        "sha256": "7539e6563acb428fdf0ca8041bd787462ae5574a52752b8679408c267eb86a10"
+      }
+    },
+    {
+      "slug": "wp-html-api",
+      "name": "wp-html-api",
+      "domain": "wordpress",
+      "description": "Use WordPress' HTML API for safe server-side HTML inspection and mutation instead of regex, fragile string replacement, or DOMDocument. Covers WP_HTML_Tag_Processor, WP_HTML_Processor, set_attribute, remove_attribute, add_class, remove_class, set_modifiable_text, serialize_token, custom data attribute name mapping, and WP 6.9 behavior where attribute/text setters escape character references. Use when plugin code modifies rendered HTML, block output, shortcodes, content filters, widget markup, email fragments, or user-provided HTML.",
+      "path": "wordpress/wp-html-api",
+      "skill_path": "wordpress/wp-html-api/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-html-api/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-html-api/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-html-api/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-html-api",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.2 - 6.9.4",
+        "php-min": "7.4",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://make.wordpress.org/core/2025/11/21/updates-to-the-html-api-in-6-9/",
+          "https://developer.wordpress.org/reference/classes/wp_html_tag_processor/",
+          "https://developer.wordpress.org/reference/classes/wp_html_processor/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 7447,
+        "lines": 181,
+        "sha256": "f1f2fef48bb349b25d107b9e4078aac455195c67682b4c9bf628d3c286b1e234"
+      }
+    },
+    {
+      "slug": "wp-i18n-audit",
+      "name": "wp-i18n-audit",
+      "domain": "wordpress",
+      "description": "Audits WordPress plugin or theme PHP code for internationalization (i18n) correctness — text-domain consistency, use of escaped translation helpers (esc_html__, esc_attr__, esc_html_e), correct placeholder helpers (sprintf with translator comments, _n for plurals, _x for context), no variable text-domains, no concatenation inside __() calls, presence of load_plugin_textdomain or load_theme_textdomain, and matching declared Text Domain in the plugin/theme header. Use before plugin/theme release, when reviewing contributor PRs, when adding new strings, when migrating to a new text domain, or when a translator reports issues with the .pot file.",
+      "path": "wordpress/wp-i18n-audit",
+      "skill_path": "wordpress/wp-i18n-audit/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-i18n-audit/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-i18n-audit/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-i18n-audit/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-i18n-audit",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.0 - 6.9",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://developer.wordpress.org/plugins/internationalization/",
+          "https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/",
+          "https://developer.wordpress.org/themes/functionality/internationalization/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 10931,
+        "lines": 297,
+        "sha256": "ade7e94b88b0850e68cc8da5c977f9178392e8a1f5561f914827c164dba93ca7"
+      }
+    },
+    {
+      "slug": "wp-locale-and-dates",
+      "name": "wp-locale-and-dates",
+      "domain": "wordpress",
+      "description": "Handle dates, times, and numbers in WordPress plugins with the modern (5.3+) locale-aware helpers — `wp_date()`, `current_datetime()`, `wp_timezone()`, `get_gmt_from_date()` / `get_date_from_gmt()`, `mysql_to_rfc3339()`, `number_format_i18n()` — and avoid the legacy foot-guns (`current_time('timestamp')` returning offset-summed not-quite-Unix, `date_i18n` quirks, `mysql_to_rfc3339` not actually being RFC3339). Covers `timezone_string` vs `gmt_offset` fallback, storing site-local + UTC MySQL columns, REST date emission, and locale-aware number formatting. Use for any plugin that stores, queries, or displays dates / numbers in multi-locale, multi-timezone installs.",
+      "path": "wordpress/wp-locale-and-dates",
+      "skill_path": "wordpress/wp-locale-and-dates/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-locale-and-dates/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-locale-and-dates/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-locale-and-dates/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-locale-and-dates",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "5.3 - 7.0",
+        "php-min": "7.4",
+        "last-updated": "2026-05-24",
+        "docs": [
+          "https://developer.wordpress.org/reference/functions/wp_date/",
+          "https://developer.wordpress.org/reference/functions/current_datetime/",
+          "https://developer.wordpress.org/reference/functions/wp_timezone/",
+          "https://make.wordpress.org/core/2019/09/23/date-time-improvements-wp-5-3/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 13908,
+        "lines": 229,
+        "sha256": "630250e4da757ebd66bc55855a709cdc22156a09718fc3c0f9bc4c1dafa5a46e"
+      }
+    },
+    {
+      "slug": "wp-presence-api",
+      "name": "wp-presence-api",
+      "domain": "wordpress",
+      "description": "Awareness-only reference for the WordPress Presence API — an EXPERIMENTAL feature plugin (v0.1.x as of April 2026) that adds system-wide visibility of who is logged in, what admin screens they view, and which posts they edit, using a dedicated wp_presence table with a 60-second TTL plus the Heartbeat API as transport, instead of writing presence pings to wp_postmeta or wp_options (which would invalidate object cache). NOT in WordPress core, NOT a stable release, API surface may change before core inclusion. Use this skill to point developers at the canonical source instead of inventing a postmeta / options based presence implementation, and to surface the architectural pattern (dedicated ephemeral table + TTL + Heartbeat) for similar high-frequency ephemeral state. Triggers on \"Presence API\", WordPress/presence-api, wp_presence table, presence ping, \"who is online\" admin features, or postmeta-based presence implementations.",
+      "path": "wordpress/wp-presence-api",
+      "skill_path": "wordpress/wp-presence-api/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-presence-api/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-presence-api/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-presence-api/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-presence-api",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "presence-api-v0.1.2",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://github.com/WordPress/presence-api",
+          "https://make.wordpress.org/core/2026/04/27/presence-api-feature-plugin/",
+          "https://make.wordpress.org/core/tag/presence-api/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 9840,
+        "lines": 134,
+        "sha256": "3019590a5a300fcd5ea6e36980c70c4ef33c1b02083bc43676ca0d02fa8b35c7"
+      }
+    },
+    {
+      "slug": "wp-query-cache",
+      "name": "wp-query-cache",
+      "domain": "wordpress",
+      "description": "Review and implement WordPress query-cache usage on WP 6.9+, especially direct interaction with query cache groups now using salted cache helpers. Covers wp_cache_get_salted, wp_cache_set_salted, wp_cache_get_multiple_salted, wp_cache_get_last_changed, affected query groups like post-queries, term-queries, user-queries, comment-queries, site-queries, and why plugins should usually use WP_Query APIs instead of writing query cache entries directly. Use when optimizing expensive reads, persistent object cache behavior, or cache invalidation bugs.",
+      "path": "wordpress/wp-query-cache",
+      "skill_path": "wordpress/wp-query-cache/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-query-cache/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-query-cache/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-query-cache/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-query-cache",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.9 - 6.9.4",
+        "php-min": "7.4",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://make.wordpress.org/core/2025/11/17/consistent-cache-keys-for-query-groups-in-wordpress-6-9/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 6533,
+        "lines": 154,
+        "sha256": "594ddd84593a7175651b85ee48cca325007ddf4172af1eb2ccacda220190d2ea"
+      }
+    },
+    {
+      "slug": "wp-rest-api",
+      "name": "wp-rest-api",
+      "domain": "wordpress",
+      "description": "Scaffolds and reviews custom WordPress REST API endpoints registered via register_rest_route on rest_api_init — namespace and version slug, permission_callback authorization (NEVER __return_true on state-changing routes, which is the most common plugin-side vulnerability on wp.org), args schema with validate_callback / sanitize_callback / type / enum, object-level capability checks via current_user_can with object ID, responses with WP_REST_Response and WP_Error carrying an HTTP status, no raw DB rows / sensitive columns in responses, cookie auth via X-WP-Nonce, REST vs admin-ajax decision. Recommends the better-route library when the plugin grows past a few endpoints. Use when scaffolding or reviewing a REST endpoint, or migrating from admin-ajax. Triggers on register_rest_route, rest_api_init, permission_callback, WP_REST_Request, WP_REST_Response, WP_Error, X-WP-Nonce, rest_ensure_response, register_rest_field, or any file path containing /rest/ or /api/ in a WP plugin or theme.",
+      "path": "wordpress/wp-rest-api",
+      "skill_path": "wordpress/wp-rest-api/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-rest-api/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-rest-api/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-rest-api/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-rest-api",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.0 - 6.9",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/",
+          "https://developer.wordpress.org/reference/functions/register_rest_route/",
+          "https://developer.wordpress.org/rest-api/using-the-rest-api/authentication/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 17587,
+        "lines": 316,
+        "sha256": "0c17f8d516e943cfa79ebefdd46b7aef1d9e114847812f15e5c4287554eb798a"
+      }
+    },
+    {
+      "slug": "wp-security-audit",
+      "name": "wp-security-audit",
+      "domain": "wordpress",
+      "description": "Audits WordPress plugin or theme PHP code for the most common security mistakes — missing nonce checks, capability checks, input sanitization, output escaping, unslashing, SQL preparation, AJAX nopriv exposure, file/path traversal, and unsafe redirects. Use when reviewing pull requests, before releasing a plugin, when the user asks \"is this secure\", or when handling code that touches $_GET / $_POST / $_REQUEST / $_COOKIE / $_FILES / $_SERVER, admin-ajax / admin-post, REST endpoints, options, user meta, custom DB queries, or file uploads.",
+      "path": "wordpress/wp-security-audit",
+      "skill_path": "wordpress/wp-security-audit/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-security-audit/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-security-audit/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-security-audit/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-security-audit",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.0 - 6.9",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://developer.wordpress.org/apis/security/",
+          "https://developer.wordpress.org/plugins/security/",
+          "https://developer.wordpress.org/reference/functions/wp_verify_nonce/",
+          "https://developer.wordpress.org/reference/functions/current_user_can/"
+        ]
+      },
+      "resources": [
+        {
+          "path": "examples/before-after-ajax.md",
+          "repo_path": "wordpress/wp-security-audit/examples/before-after-ajax.md",
+          "type": "example",
+          "bytes": 2268,
+          "sha256": "d627eb580eaa60904cc8fad5ac1798810c4874628d61dfb02989ad55531b4223"
+        },
+        {
+          "path": "reference.md",
+          "repo_path": "wordpress/wp-security-audit/reference.md",
+          "type": "reference",
+          "bytes": 10629,
+          "sha256": "5540a2b8c3b4f35b7d2fab2fdaf95bf9cdd47e6418c37e40bd482e69e95933b1"
+        }
+      ],
+      "has_reference": true,
+      "has_examples": true,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 10346,
+        "lines": 269,
+        "sha256": "ad19077971e864e05222ded64d24d7d58bfe55eb2f0a6da1e88423b92375e2a5"
+      }
+    },
+    {
+      "slug": "wp-security-deep",
+      "name": "wp-security-deep",
+      "domain": "wordpress",
+      "description": "Deep security audit for WordPress plugin/theme PHP code, covering issues beyond the basic sanitize/escape/nonce checklist — PHP object injection (unserialize), SSRF in remote requests, CSRF on state-changing GET handlers, mass assignment via $_POST loops, insecure file include / template injection, mail header injection, ZipSlip in archive extraction, type-juggling in auth comparisons, and TOCTOU race patterns in option/meta locks. Use after or alongside wp-security-audit when reviewing complex plugins, REST APIs, integrations that fetch remote URLs, file processors, or any code that handles uploads, archives, or self-rolled auth tokens.",
+      "path": "wordpress/wp-security-deep",
+      "skill_path": "wordpress/wp-security-deep/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-security-deep/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-security-deep/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-security-deep/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-security-deep",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.0 - 6.9",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://developer.wordpress.org/plugins/security/",
+          "https://www.php.net/manual/en/function.unserialize.php",
+          "https://www.php.net/manual/en/function.hash-equals.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 13405,
+        "lines": 382,
+        "sha256": "5d669c195869bd1b1469efef971dcb2556fbf302f73ca5510f7908da33d35ddb"
+      }
+    },
+    {
+      "slug": "wp-security-secrets",
+      "name": "wp-security-secrets",
+      "domain": "wordpress",
+      "description": "Audits WordPress plugin/theme code for secret-handling and credential issues — hardcoded API keys, DB credentials, or signing secrets in source; weak randomness (rand, mt_rand, uniqid) used for security tokens, password reset links, nonces, or session IDs; password storage with md5/sha1/crypt instead of password_hash; insecure cookie flags (missing Secure, HttpOnly, SameSite) on sensitive cookies; secrets logged via error_log / var_dump in production code paths. Use before plugin release, when reviewing auth/registration/login features, when integrating third-party APIs, or when the user mentions \"API key\", \"token\", \"session\", \"password reset\".",
+      "path": "wordpress/wp-security-secrets",
+      "skill_path": "wordpress/wp-security-secrets/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-security-secrets/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-security-secrets/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-security-secrets/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-security-secrets",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.0 - 6.9",
+        "php-min": "7.4",
+        "last-updated": "2026-04-28",
+        "docs": [
+          "https://www.php.net/manual/en/function.password-hash.php",
+          "https://www.php.net/manual/en/function.random-bytes.php",
+          "https://developer.wordpress.org/reference/functions/wp_generate_password/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 10073,
+        "lines": 279,
+        "sha256": "69ce6b0d7406193c822e28bd4c0f27f747660b2d5f96ddd4cd86f7e7fe3baf84"
+      }
+    },
+    {
+      "slug": "wp-utf8-text",
+      "name": "wp-utf8-text",
+      "domain": "wordpress",
+      "description": "Handle UTF-8 and text encoding safely in WordPress plugins, especially on WP 6.9+ where wp_is_valid_utf8(), wp_scrub_utf8(), and noncharacter helpers replace older seems_utf8-style checks. Covers when to validate, scrub, reject, or preserve invalid bytes; wp_check_invalid_utf8 behavior; XML/JSON/feed/export boundaries; and avoiding data loss from premature replacement. Use when processing imported text, CSV, XML, feeds, email, REST payloads, AI prompts, logs, filenames, or external API data.",
+      "path": "wordpress/wp-utf8-text",
+      "skill_path": "wordpress/wp-utf8-text/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-utf8-text/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wordpress/wp-utf8-text/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wordpress/wp-utf8-text/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wordpress/wp-utf8-text",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wordpress",
+        "plugin-version-tested": "6.9 - 6.9.4",
+        "php-min": "7.4",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://make.wordpress.org/core/2025/11/18/modernizing-utf-8-support-in-wordpress-6-9/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 6229,
+        "lines": 159,
+        "sha256": "dd5372c6d736324fccdc6f46b43f19e95eac4bff782b493550a66ab0d26a6696"
+      }
+    },
+    {
+      "slug": "wp-rocket-cache-invalidation",
+      "name": "wp-rocket-cache-invalidation",
+      "domain": "wp-rocket",
+      "description": "Programmatically clear WP Rocket cache from a third-party plugin / theme when data changes — the public rocket_clean_* function family (rocket_clean_post, rocket_clean_files, rocket_clean_term, rocket_clean_user, rocket_clean_home, rocket_clean_minify, rocket_clean_cache_busting, rocket_clean_domain, rocket_clean_cache_dir). Critical detection rule — WP Rocket is a PAID plugin not on Packagist; always feature-detect via function_exists('rocket_clean_post') OR defined('WP_ROCKET_VERSION') before calling, since not every site has it. Never raw-unlink the cache directory or call wp_cache_flush() expecting it to clear WP Rocket — wp_cache_flush is WP object cache, WP Rocket is FILE cache. The before_*_clean_* / after_*_clean_* action lifecycle hooks fire around every clean — useful for audit logging, monitoring, custom invalidation chains. Use when integrating cache invalidation in a companion plugin, WC integration, custom data plugin. Triggers on rocket_clean_, before_rocket_clean, after_rocket_clean, \"WP Rocket cache invalidate / purge / clear\".",
+      "path": "wp-rocket/wp-rocket-cache-invalidation",
+      "skill_path": "wp-rocket/wp-rocket-cache-invalidation/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wp-rocket/wp-rocket-cache-invalidation/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wp-rocket/wp-rocket-cache-invalidation/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wp-rocket/wp-rocket-cache-invalidation/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wp-rocket/wp-rocket-cache-invalidation",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wp-rocket",
+        "plugin-version-tested": "3.21.1",
+        "php-min": "7.3",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://docs.wp-rocket.me/article/92-plugin-compatibility-with-wp-rocket",
+          "https://docs.wp-rocket.me/article/2-getting-started"
+        ],
+        "source-refs": [
+          "wp-content/plugins/wp-rocket/wp-rocket.php",
+          "wp-content/plugins/wp-rocket/inc/common/purge.php",
+          "wp-content/plugins/wp-rocket/inc/functions/files.php"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 20706,
+        "lines": 403,
+        "sha256": "b7d80364f300b27632f0ccbfc3c430d9f5b919ea8b0d2e96738bec0ae3003a57"
+      }
+    },
+    {
+      "slug": "wp-rocket-cache-rejection-and-filters",
+      "name": "wp-rocket-cache-rejection-and-filters",
+      "domain": "wp-rocket",
+      "description": "Customize WP Rocket behavior from a third-party plugin / theme via filter hooks — exclude URIs / cookies / user agents / REST API namespaces from caching, configure CDN URL rewrites, extend lazy load handling, override capability requirements, hook into Action Scheduler integration. Critical guidance — rocket_cache_reject_uri takes URI patterns (regex-like), NOT full URLs; rocket_cache_reject_* filters all expect arrays. The rocket_buffer filter is the FULL HTML output filter — extremely powerful but dangerous; one fatal error in the callback breaks every cached page until WP Rocket is disabled. Use when extending WP Rocket's default rules, NOT for cache invalidation (see wp-rocket-cache-invalidation). Triggers on rocket_cache_reject_, rocket_cdn_, do_rocket_lazyload, rocket_buffer, rocket_capacity, \"exclude from WP Rocket cache\".",
+      "path": "wp-rocket/wp-rocket-cache-rejection-and-filters",
+      "skill_path": "wp-rocket/wp-rocket-cache-rejection-and-filters/SKILL.md",
+      "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wp-rocket/wp-rocket-cache-rejection-and-filters/SKILL.md",
+      "raw_url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/wp-rocket/wp-rocket-cache-rejection-and-filters/SKILL.md",
+      "html_url": "https://github.com/Lonsdale201/wp-agent-skills/blob/main/wp-rocket/wp-rocket-cache-rejection-and-filters/SKILL.md",
+      "directory_url": "https://github.com/Lonsdale201/wp-agent-skills/tree/main/wp-rocket/wp-rocket-cache-rejection-and-filters",
+      "metadata": {
+        "author": "Soczó Kristóf",
+        "contact": "mailto:lonsdale201@hotmail.com",
+        "plugin": "wp-rocket",
+        "plugin-version-tested": "3.21.1",
+        "php-min": "7.3",
+        "last-updated": "2026-04-29",
+        "docs": [
+          "https://docs.wp-rocket.me/article/92-plugin-compatibility-with-wp-rocket",
+          "https://docs.wp-rocket.me/article/2-getting-started"
+        ],
+        "source-refs": [
+          "wp-content/plugins/wp-rocket/wp-rocket.php",
+          "wp-content/plugins/wp-rocket/inc/functions/options.php",
+          "wp-content/plugins/wp-rocket/inc/Engine/Optimization/Buffer/Optimization.php",
+          "wp-content/plugins/wp-rocket/inc/Engine/CDN/",
+          "wp-content/plugins/wp-rocket/inc/Engine/Media/Lazyload/"
+        ]
+      },
+      "resources": [],
+      "has_reference": false,
+      "has_examples": false,
+      "has_scripts": false,
+      "skill_md": {
+        "bytes": 22280,
+        "lines": 501,
+        "sha256": "6e766d5022c2691f791dc688a855d68191d78acab146ccf2a99e8386b6acf68b"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds a generated machine-readable skill catalog for tooling.

Changes:
- add `.github/scripts/build-skills-index.js`
- add committed `skills-index.json`
- add JSON Schema for the index
- add CI check to keep the index synchronized
- regenerate the index automatically in issue-created skill PRs
- document the index in README

Validation run locally:
- `node .github/scripts/build-skills-index.js --check`
- JSON parse check for `skills-index.json` and `schemas/skills-index.v1.json`