### PR TITLE
lw-plugins: re-ground LW Firewall skills on 1.5.6

### DIFF
--- a/lw-plugins/lw-firewall-custom-form-adapter/SKILL.md
+++ b/lw-plugins/lw-firewall-custom-form-adapter/SKILL.md
@@ -5,15 +5,15 @@ metadata:
   wp-skills-author: "Soczó Kristóf"
   wp-skills-contact: "mailto:lonsdale201@hotmail.com"
   wp-skills-plugin: "lw-firewall"
-  wp-skills-plugin-version-tested: "1.5.4"
+  wp-skills-plugin-version-tested: "1.5.6"
   wp-skills-wp-version-tested: "7.1"
   wp-skills-php-min: "8.2"
-  wp-skills-last-updated: "2026-08-27"
+  wp-skills-last-updated: "2026-08-29"
 ---
 
 # LW Firewall custom-form adapter
 
-LW Firewall 1.5.4 has dedicated guards for core registration and password
+LW Firewall 1.5.6 has dedicated guards for core registration and password
 reset. It does not expose a generic “attach this firewall to any form” service,
 field descriptor, render/validate interface, or form registry.
 
@@ -43,16 +43,30 @@ counters, and can create a misleading `register_spam` ban.
 version-pinned adapter and explicit fallback policy; their class names and
 settings remain registration-oriented.
 
-The token in v1.5.4 signs only a timestamp. A developer-provided `$scope` is
-used solely in the replay-storage key, not in the signed token. Consequently a
-token is not cryptographically bound to the custom form, route, field name,
-user, or scope. Tokens minted in one second are identical and can collide under
-single-use enforcement.
+**The token format changed in 1.5.6 — this is a breaking change for adapters.**
+The payload is now `v2.<issued>.<scope>.<nonce>`, HMAC-signed as a whole, where
+the nonce is 16 random bytes per render. Three consequences:
 
-If form binding, cryptographic randomness, or high-assurance proof is required,
-the current primitive is insufficient. Use a purpose-built random, signed,
-form-bound protocol or an external challenge; do not hide the limitation behind
-an adapter name.
+- **The scope is signed, not just a storage-key prefix.** A token issued with
+  one scope can no longer be presented to another form — but it also means
+  `issue()` and `verify()` **must be given the same scope**. `issue()` defaults
+  to `'reg'`, so an adapter that calls a bare `issue()` and verifies with its
+  own scope now fails every submission. Always pass the scope on both sides.
+- **Same-second renders are distinct.** The 1.5.4 collision (identical tokens
+  within one second, single-use rejecting all but the first, a shared page cache
+  handing one token to everybody) is gone.
+- **Scope is normalized** to `[a-z0-9_-]` after `strtolower()`, and other
+  characters are stripped — `my form!` and `myform` are the same scope. Pick a
+  scope that is already in that alphabet.
+
+The format version is signed too, so a token rendered by 1.5.4 does not verify
+on 1.5.6. Expect a burst of rejections from cached pages immediately after the
+upgrade; that is the intended fail-closed behaviour, not a defect.
+
+The primitive is now a per-render, signed, form-bound proof of render. It is
+still not identity or a CAPTCHA: it proves a form was rendered, not who
+rendered it. For high-assurance proof, use a purpose-built protocol or an
+external challenge; do not hide the limitation behind an adapter name.
 
 ## Minimal adapter pattern
 
@@ -79,7 +93,9 @@ final class MyFormProof
         }
 
         return [
-            self::TOKEN => RegisterToken::issue(),
+            // Pass the scope: it is signed into the token in 1.5.6, and
+            // verify() below must be given the same one.
+            self::TOKEN => RegisterToken::issue(self::SCOPE),
             self::HONEYPOT => '',
         ];
     }
@@ -172,7 +188,7 @@ transport-neutral form-guard contract with:
 Read [generic-form-guard-proposal.md](references/generic-form-guard-proposal.md)
 for the proposed PHP contract, threat boundaries, hooks and acceptance tests.
 That document is a design proposal for a later LW Firewall version, not an API
-available in 1.5.4.
+available in 1.5.6.
 
 ## Layers the adapter must not replace
 
@@ -187,8 +203,11 @@ available in 1.5.4.
 
 - Valid, missing, filled, and omitted honeypot.
 - Valid, tampered, too-young, expired, and replayed token.
-- Two tokens issued in the same second for the same scope.
-- Token minted for one adapter and submitted to another scope.
+- Two tokens issued in the same second for the same scope (must both succeed).
+- Token minted for one adapter and submitted to another scope (must fail).
+- A token issued without an explicit scope and verified with one (must fail —
+  this is the common adapter bug after the 1.5.6 format change).
+- A token in the pre-1.5.6 format (must fail closed).
 - Shared-cache delivery to multiple anonymous clients.
 - Plugin inactive, helper unavailable, master disabled, and chosen fail policy.
 - Form-specific rate threshold and atomic concurrency.

--- a/lw-plugins/lw-firewall-custom-form-adapter/references/generic-form-guard-proposal.md
+++ b/lw-plugins/lw-firewall-custom-form-adapter/references/generic-form-guard-proposal.md
@@ -1,7 +1,7 @@
 # Proposed generic form-guard contract
 
 This is an upstream design proposal for a future LW Firewall release. It is
-not part of LW Firewall 1.5.4, and companion plugins must not feature-detect or
+not part of LW Firewall 1.5.6, and companion plugins must not feature-detect or
 call the names below until the plugin ships a documented equivalent.
 
 ## Goal and boundary
@@ -78,9 +78,13 @@ form ID inside the signed payload and derive the replay key from both the form
 ID and nonce ID. Do not bind the client IP by default: mobile networks, proxies
 and privacy relays can legitimately change it between render and submit.
 
-The current 1.5.4 timestamp-only token is not a suitable wire format for this
-API because same-second renders collide and the caller's replay scope is not
-signed.
+As of 1.5.6 `RegisterToken` already meets most of this: the payload is
+`v2.<issued>.<scope>.<nonce>` with a 16-byte per-render nonce, HMAC-signed, so
+same-second renders no longer collide and the caller's scope IS signed. What a
+generic guard would still add on top is a public, versioned contract (the class
+name and its options remain registration-oriented), a caller-supplied form ID
+distinct from the replay scope, transport-neutral validation, and a documented
+fail policy. Treat the wire format as adequate and the API surface as the gap.
 
 ## Transport-neutral validation
 
@@ -158,7 +162,7 @@ argument shapes and whether a hook may change the verdict.
    follow the documented policy.
 10. Public errors do not reveal which anti-bot check failed.
 
-## Verified 1.5.4 source boundary
+## Verified 1.5.6 source boundary
 
 - `includes/Rules/RegisterToken.php`
 - `includes/Rules/RegisterGuard.php`

--- a/lw-plugins/lw-firewall-management-abilities/SKILL.md
+++ b/lw-plugins/lw-firewall-management-abilities/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: lw-firewall-management-abilities
-description: Manage and audit LW Firewall 1.5.4 through its options API, admin UI, WP-CLI, LW Site Manager abilities, worker controls, logs, administrator alerts, password-reset settings, and manual or automatic IP bans. Use when code or runbooks reference `wp lw-firewall`, `Options::save`, `LW_FIREWALL_*`, `lw-firewall/get-options`, `block-ip`, `lw_firewall_bans`, `BanList`, `AutoBanner::unban`, worker reinstall, alert baseline, reset protection, import/export, or firewall configuration migration.
+description: Manage and audit LW Firewall 1.5.6 through its options API, admin UI, WP-CLI, LW Site Manager abilities, worker controls, logs, administrator alerts, password-reset settings, and manual or automatic IP bans. Use when code or runbooks reference `wp lw-firewall`, `Options::save`, `LW_FIREWALL_*`, `lw-firewall/get-options`, `block-ip`, `lw_firewall_bans`, `BanList`, `AutoBanner::unban`, worker reinstall, alert baseline, reset protection, import/export, or firewall configuration migration.
 metadata:
   wp-skills-author: "Soczó Kristóf"
   wp-skills-contact: "mailto:lonsdale201@hotmail.com"
   wp-skills-plugin: "lw-firewall"
-  wp-skills-plugin-version-tested: "1.5.4"
+  wp-skills-plugin-version-tested: "1.5.6"
   wp-skills-wp-version-tested: "7.1"
   wp-skills-php-min: "8.2"
-  wp-skills-last-updated: "2026-08-27"
+  wp-skills-last-updated: "2026-08-29"
 ---
 
 # LW Firewall management, abilities and CLI
@@ -33,11 +33,27 @@ Do not assume a new admin or CLI feature also exists as an ability.
 The persisted option is `LightweightPlugins\Firewall\Options::OPTION_NAME`,
 whose value is `lw_firewall`.
 
-`Options::get_all()` merges stored values with defaults and normalizes list
-keys. `Options::save()` accepts a partial array, preserves other known values,
-and persists only keys present in `get_defaults()`. It does not run the admin
-form's type/range/IP/country validation; programmatic callers must supply
-validated values of the correct type:
+There are now three read views, and picking the wrong one is the classic bug:
+
+| Call | Returns |
+|---|---|
+| `Options::get_stored()` | defaults + database, **no** constant overlay — the editing/persistence view |
+| `Options::get_all()` | stored values with `LW_FIREWALL_*` constants layered on top — the **effective runtime** view |
+| `Options::get($key)` | the constant if defined, otherwise the `get_all()` value |
+| `Options::overridden()` | the option keys a constant currently pins |
+
+Since 1.5.5 `get_all()` applies constants (it did not in 1.5.4, which is why the
+worker, the hook bootstrap, the `.htaccess` sync and the status screen all ran
+on a configuration the operator had not chosen). Saving reads `get_stored()`,
+so a pinned value is never written into the database and never survives the
+constant's removal.
+
+`Options::save()` accepts a partial array, preserves other known values, and
+persists only keys present in `get_defaults()`. Since 1.5.6 it also runs
+`OptionSchema::apply()` on **every** key — one server-side value policy that
+clamps numeric ranges and allowlists enums for the form, WP-CLI and the settings
+import alike. Passing a well-typed value is still good practice, but a bad one
+is now clamped rather than stored:
 
 ```php
 use LightweightPlugins\Firewall\Options;
@@ -52,22 +68,22 @@ Do not call `update_option('lw_firewall', $partial)`; that bypasses the merge,
 normalization, and known-key boundary.
 
 List keys are `filter_params`, `blocked_bots`, `ip_whitelist`, `ip_blacklist`,
-and `blocked_countries`.
+`blocked_countries`, and `trusted_proxies`.
 
-`geo_action` is currently persisted and rendered as `403`/`redirect`, but the
-1.5.4 PHP worker always calls its 403 response and the generated `.htaccess`
-rule always uses `[F,L]`. Do not promise or test a redirect as an effective
-runtime choice until the implementation consumes this option.
+`geo_action` was **removed in 1.5.5**. It had never been read at runtime — the
+worker always returned 403 and the `.htaccess` rule was always `[F,L]` — and it
+is unimplementable as documented, since geo blocking applies to every path and
+redirecting a blocked visitor to the homepage would loop. Do not reference the
+option, and drop it from migrations and import files.
 
-`Options::get($key)` checks `LW_FIREWALL_<UPPERCASE_KEY>` first. Constants can
-therefore make a single option read differ from the saved value. However,
-`Options::get_all()` does not overlay constants. The 1.5.4 worker, its main
-runtime-hook bootstrap, the admin screen and several status/management paths
-use `get_all()`, so many documented constants do not affect or even accurately
-describe those paths. This includes the master/toggle/list/storage decisions;
-verify each intended override with a real request. `LW_FIREWALL_DISABLE_WORKER`
-is checked directly and remains a separate early-worker kill switch;
-`LW_FIREWALL_LOGGEDIN_MULTIPLIER` is also read directly.
+New in 1.5.6: `trusted_proxies` and `proxy_header` (IP Rules → Reverse Proxy).
+Opt-in reverse-proxy support; without it a site behind nginx-on-the-same-host
+sees every visitor as `127.0.0.1`, which the worker treats as the server's own
+address — a silent total bypass. See `lw-firewall-rate-limit-worker`.
+
+`LW_FIREWALL_DISABLE_WORKER` is checked directly and remains a separate
+early-worker kill switch; `LW_FIREWALL_LOGGEDIN_MULTIPLIER` is also read
+directly.
 
 ## WP-CLI map
 
@@ -111,7 +127,8 @@ confirm an alternative recovery path first.
 
 ## Site Manager abilities
 
-When LW Site Manager is active, v1.5.4 registers exactly these abilities:
+When LW Site Manager is active, v1.5.6 registers exactly these abilities (the
+set is unchanged since 1.5.4):
 
 | Ability | Operation |
 |---|---|
@@ -126,13 +143,24 @@ through ability metadata. There are no ability contracts for automatic bans,
 alerts, reset controls, worker install, or full option writes. Do not call the
 manual `unblock-ip` ability to release an automatic ban.
 
-In v1.5.4 the ability's CIDR validator casts the suffix before validating its
-syntax. Values such as `10.0.0.0/foo` and `10.0.0.0/24junk` are accepted; the
-runtime matcher then treats `foo` as prefix zero, which can match every address
-in that IP family. Validate an exact decimal suffix and its family-specific
-range in the calling workflow. The write abilities also read-modify-write the
-whole option without concurrency control and do not check `Options::save()`'s
-result before returning success.
+The dangerous half of the 1.5.4 CIDR defect is fixed, the cosmetic half is not
+— and the distinction matters:
+
+- **Fixed (1.5.5, in `IpMatcher::ip_in_cidr()`).** The prefix must be an exact
+  decimal (`ctype_digit`) within the family's range. `10.0.0.0/foo` and
+  `10.0.0.0/-1` no longer collapse to a zero-width mask, so one typo in the
+  whitelist can no longer disable the firewall and one in the blacklist can no
+  longer take the site down. A malformed rule simply never matches.
+- **Not fixed (`FirewallService::is_valid_ip_or_cidr()`).** The ability's own
+  validator still casts the suffix with `(int)` before range-checking, so
+  `10.0.0.0/foo` is still *accepted and stored*. It is now inert rather than
+  catastrophic, but it is a rule the operator believes is active and is not.
+  Validate an exact decimal suffix and its family-specific range in the calling
+  workflow.
+
+The write abilities still read-modify-write the whole option without
+concurrency control and still do not check `Options::save()`'s result before
+returning success.
 
 The block/unblock abilities are marked `destructive: false`. Blocking the
 caller's own IP is still a site-wide access-policy change with a lockout risk,
@@ -145,19 +173,24 @@ require explicit confirmation even though the annotation does not request it.
 - Enforced automatic ban: TTL key `ban_<ip>` in the selected storage backend.
 - Listable automatic-ban index: non-autoloaded `lw_firewall_bans`, capped at 500.
 
+Ban durations are clamped since 1.5.6: a zero duration used to mean "no TTL" to
+every backend, i.e. an accidentally permanent ban.
+
 The storage key is authoritative. The index records IP, reason, start and
 rounded expiry so administrators can list and remove bans; an entry may remain
 temporarily visible as inactive after storage loss/expiry.
 
 Use `AutoBanner::unban($ip)` or the `ban remove` command, not raw option or
-storage deletion. It removes the ban key, its index row, and several producer
-counters. In v1.5.4 it does not clear the worker's reason-specific
-`<reason>_<ip>` or `<reason>_li_<ip>` rate buckets, so the IP may still receive
-429 until `rate_window` expires.
+storage deletion. It removes the ban key, its index row, the producer counters
+and — since 1.5.5 — the worker's reason-specific `<reason>_<ip>` /
+`<reason>_li_<ip>` rate buckets, so a released address is actually released
+instead of staying 429 until `rate_window` aged out.
 
-Also verify enforcement: the worker currently checks shared ban keys only when
-`auto_ban_enabled` or `login_limit_enabled` is true. A registration/reset ban
-can be indexed but dormant when both are off.
+Enforcement is also no longer conditional: since 1.5.5 the worker reads the ban
+key whenever the firewall is on. A registration or password-reset ban is no
+longer indexed-but-dormant while `auto_ban_enabled` and `login_limit_enabled`
+are off. Still verify with a real follow-up request — the storage key, not the
+index row, is the authority.
 
 ## Administrator alerts and reset protection
 
@@ -174,35 +207,43 @@ limits or proof settings.
 
 ## Import, logs and worker
 
-Admin import accepts known keys, fills missing keys from defaults, and cleans
-list values plus country codes. In v1.5.4 it does not run the admin form's full
-scalar type/range validation before `Options::save()`. Treat imported JSON as
-untrusted: validate booleans, integers, enums, IP/CIDR values, email recipients,
-and policy before production. A syntactically valid file can also intentionally
-enable broad blocking.
+The 1.5.4 gap this skill described as "until a central option schema exists"
+is closed. `OptionSchema` (`includes/OptionSchema.php`) is now the single
+server-side value policy: `ranges()` clamps every numeric setting, `enums()`
+allowlists every enumerated one, and `Options::save()` runs `apply()` over all
+keys. The form, WP-CLI (`config set`, `config-items`, `ip add`) and the settings
+import therefore share one policy — the form's only numeric bounds used to be
+HTML `min`/`max` attributes, which nothing but a browser enforces.
 
-The admin form itself applies `absint()` and `sanitize_key()` but does not
-enforce the HTML controls' numeric bounds or enum allowlists server-side. The
-IP textareas and general `config set` / `config-items` / `ip add` CLI paths also
-do not share the Site Manager validator. Treat every management surface as a
-typed-but-not-policy-validated caller until a central option schema exists.
+That is type/range/enum policy, not trust. Imported JSON is still untrusted
+input: a syntactically valid, fully in-range file can intentionally enable broad
+blocking, blacklist the operator's own range, or redirect alert mail. Review
+IP/CIDR values, country codes, email recipients and blocking policy before
+importing into production. The Site Manager ability validator still differs
+from `IpMatcher` (see above).
 
 `lw_firewall_log` holds at most 100 newest entries and is written only when
 `log_enabled` is true. Rows contain IP, reason, User-Agent, URL and time; treat
-them as operational/personal data. The row cap does not cap writes: every
-blocked request may read and rewrite the option, so enable logging cautiously
-under a live flood.
+them as operational/personal data. Since 1.5.6 `Logger` collapses a repeated
+IP/reason pair for five minutes into one counted entry, so a flood no longer
+rewrites the option on every blocked request — the write amplification is
+bounded, not gone, since distinct IPs still each write.
 
-Administrator alert hooks and scans advance the baseline before/independently
-of confirmed mail delivery. If `wp_mail()` fails, a transient warns the admin,
-but that security event is already considered known and is not retried. The
-manual scan UI/CLI can also report that an alert was sent without checking the
-mailer result returned inside the scanner. Monitor delivery externally; a
-successful scan is not proof that the notification arrived.
+Alert delivery is now retried. `AlertQueue` holds notifications whose send
+failed and the next scan retries them, giving up only after a capped number of
+attempts (the admin transient still shows the failure). The baseline snapshot is
+explicitly a **deduplication record, not a delivery receipt** — treating it as
+one is what let a single SMTP hiccup permanently lose the notice that an
+administrator had appeared. Still monitor transport externally: a scan that
+reports success means the alert was queued or sent, not that it was received.
 
 The worker is expected at `wp-content/mu-plugins/lw-firewall-worker.php`. A
-missing or mismatched worker triggers one repair attempt and an admin notice.
-Never edit the installed copy because activation and upgrade overwrite it.
+missing or mismatched worker triggers one repair attempt and an admin notice;
+since 1.5.6 the check compares file content (`filemtime`) as well as the version
+constant, and the worker writes a `lw_firewall_worker_alive` transient so the
+Status tab can distinguish "installed" from "has actually run". Manage it with
+`wp lw-firewall worker install|remove`. Never edit the installed copy because
+activation and upgrade overwrite it.
 
 ## Automation checklist
 
@@ -213,8 +254,9 @@ Never edit the installed copy because activation and upgrade overwrite it.
 - Distinguish manual blacklist, active storage ban, and listable ban index.
 - Confirm worker version and active storage before interpreting ban state.
 - Confirm logging before relying on logs and redact them from non-admin output.
-- Confirm alert transport delivery; do not acknowledge an incident only from
-  baseline advancement or the scan command's success text.
+- Confirm alert transport delivery; a queued/retried alert is not a received
+  one, and the scan command's success text is not a delivery receipt.
+- Check `Options::overridden()` before telling an operator a setting took effect.
 - Treat `alerts baseline --reset` as a security-state mutation requiring review.
 - Verify ban removal with a real follow-up request, not only an index row.
 - Use WP-CLI/admin for features absent from Site Manager abilities.
@@ -241,6 +283,11 @@ Never edit the installed copy because activation and upgrade overwrite it.
   - `includes/CLI/BanCommand.php`
   - `includes/CLI/ResetCommand.php`
   - `includes/CLI/AlertsCommand.php`
+  - `includes/OptionSchema.php`
+  - `includes/Logger.php`
+  - `includes/Alerts/AlertQueue.php`
+  - `includes/Rules/IpMatcher.php`
+  - `includes/CLI/WorkerCommand.php`
   - `includes/SiteManager/FirewallAbilities.php`
   - `includes/SiteManager/FirewallService.php`
   - `docs/management.md`

--- a/lw-plugins/lw-firewall-password-reset-protection/SKILL.md
+++ b/lw-plugins/lw-firewall-password-reset-protection/SKILL.md
@@ -5,10 +5,10 @@ metadata:
   wp-skills-author: "Soczó Kristóf"
   wp-skills-contact: "mailto:lonsdale201@hotmail.com"
   wp-skills-plugin: "lw-firewall"
-  wp-skills-plugin-version-tested: "1.5.4"
+  wp-skills-plugin-version-tested: "1.5.6"
   wp-skills-wp-version-tested: "7.1"
   wp-skills-php-min: "8.2"
-  wp-skills-last-updated: "2026-08-27"
+  wp-skills-last-updated: "2026-08-29"
 ---
 
 # LW Firewall password-reset protection
@@ -26,7 +26,7 @@ The reset guard initializes only when the MU worker is current, master
 |---|---|
 | `lostpassword_form` | render `lw_fw_reset_token` and `lw_fw_confirm_url` on core `wp-login.php` |
 | `lostpassword_post` | apply proof decision and three rate-limit axes before mail |
-| `allow_password_reset` | optionally refuse the `administrator` role when `reset_block_admins` is on |
+| `allow_password_reset` | optionally refuse every privileged account when `reset_block_admins` is on |
 
 Core `retrieve_password()` and WooCommerce's account implementation both fire
 `lostpassword_post` with `WP_Error` and `WP_User|false`, so their valid-account
@@ -58,20 +58,24 @@ than automatic reset-guard coverage.
 | Target account | 3 per 3600 seconds | `reset_user_<user-id>` | one known account |
 
 The first `max` attempts pass; the next is rejected because the comparison is
-`count > max`. A maximum of zero disables that axis. IP short-circuits global
-and target; global short-circuits target. The target uses user ID, so login,
-case variants resolved by WordPress, and email share a bucket.
+`count > max`. A maximum of zero disables that axis. The target uses user ID, so
+login, case variants resolved by WordPress, and email share a bucket.
+
+**Evaluation order changed in 1.5.6:** `ResetLimiter::record()` now charges
+**IP → target account → site-wide**, so the hourly email cap is charged last and
+only by a request that has cleared everything else. Charging it first let
+refused requests drain it: a flood against one account could exhaust the quota
+and deny password resets to every other user until the window rolled over.
+`record_rejected()` charges the sender's IP allowance only — bot traffic still
+earns its own ban but no longer spends the target's allowance or the site's
+email budget.
 
 `PasswordResetGuard` returns immediately when core/Woo has already put an error
 on the `WP_Error`, so unknown/empty accounts are not counted by this guard.
 
-The global counter is incremented before the target-account counter. Once one
-known account is over its target limit, later distributed attempts for that
-account still consume the global allowance before returning `user`. After the
-global maximum, the verdict changes to `global` and resets for every account
-are refused. Therefore the current counter is not the documented count of
-emails actually sent; treat it as a site-wide request budget with a distributed
-denial-of-service edge.
+The site-wide counter is still a request budget rather than a count of emails
+actually sent, but the 1.5.4 denial-of-service edge is closed: a request refused
+on the IP or target axis no longer charges it.
 
 ## Exemptions and refusal behavior
 
@@ -89,26 +93,37 @@ global limits never ban the last requester. Alerts use the Alerts-tab recipient
 policy and are throttled once per verdict per hour. Public messages remain
 generic within the proof/rate categories.
 
-## Verified v1.5.4 constraints
+## Verified v1.5.6 constraints
 
-- Reset and registration use the same timestamp-only `RegisterToken` format.
-  The `reset` argument namespaces only the single-use key; it is not signed into
-  the token and does not bind the token to the reset form.
-- Tokens minted in the same second are identical. Two reset forms rendered in
-  that second collide when single use is enabled.
+Fixed since this skill's 1.5.4 grounding — do not re-report these:
+
+- **The proof token is now form-bound and per-render.** `RegisterToken` signs a
+  per-render nonce and a scope into the payload, so tokens minted in the same
+  second are no longer identical (a shared page cache used to hand one token to
+  every visitor, and single-use rejected all but the first), and a token issued
+  by one form can no longer be presented to another. `verify()` and `check()`
+  take the scope as their fifth argument — pass the same scope you issued with.
+- **The site-wide counter is charged last** (see above), so failed-proof and
+  target-refused traffic no longer drains it.
+- **`reset_block_admins` covers every privileged account**, not just the
+  `administrator` role slug: multisite super admins and any custom role holding
+  `manage_options` are included.
+- **A reset ban is enforced whenever the firewall is on.** The worker's
+  shared-ban lookup is no longer gated on `auto_ban_enabled` /
+  `login_limit_enabled`, so `reset_auto_ban` alone now produces a real block.
+
+Still true in 1.5.6:
+
 - The honeypot checks only for a non-empty value; an omitted field is accepted.
-- A failed proof is passed through the IP/global limiter before its verdict is
-  overwritten to `spam`. Distributed valid-account spam can therefore consume
-  the global allowance even though those failed-proof requests send no email.
-- Requests already destined for a `user` refusal also increment the global
-  counter first. Repeating one known target across enough IPs can exhaust the
-  site-wide allowance after only the first target-limited emails were sent.
-- A reset ban is enforced by the worker only when `auto_ban_enabled` or
-  `login_limit_enabled` is also true; `reset_auto_ban` alone does not enable the
-  worker's shared-ban lookup.
+- The proof token is enforced only on `wp-login.php`, because
+  `lostpassword_form` is the only place it is rendered. Woo, custom and REST
+  reset paths get the rate limits but no LW proof check.
+- `reset_block_admins` answers differently for a privileged account, which
+  allows administrator enumeration. Upstream lists this as known and not fixed:
+  closing it needs the same generic-response handling as lost-password user
+  enumeration.
 
-Treat these as current implementation facts and regression-test them around any
-companion behavior. Do not advertise the token as form-bound human proof.
+Regression-test these around any companion behavior.
 
 ## Configuration and operations
 
@@ -145,11 +160,13 @@ it. `reset off` preserves the other values.
 - Keep anti-enumeration behavior consistent with the product's reset policy.
 - Test valid account, invalid account, IP/global/target thresholds, and recovery after TTL.
 - Test core, WooCommerce, custom POST, REST, privileged admin, CLI, and whitelisted IP.
-- Test same-second tokens and single-use replay on `wp-login.php`.
+- Test same-second tokens and single-use replay on `wp-login.php`, and assert a
+  reset-scope token is refused by the registration form (and vice versa).
 - Verify that an indexed reset ban is actually enforced and removable.
-- Test distributed failed-proof traffic against the global allowance.
-- Test repeated target-limited traffic from changing IPs and assert how many
-  actual emails versus `reset_all` increments occurred.
+- Assert that failed-proof and target-refused traffic does NOT charge
+  `reset_all` — that ordering is the 1.5.6 fix and is easy to regress.
+- Test `reset_block_admins` against a multisite super admin and a custom role
+  holding `manage_options`, not only the `administrator` slug.
 
 ## Cross-references
 

--- a/lw-plugins/lw-firewall-rate-limit-worker/SKILL.md
+++ b/lw-plugins/lw-firewall-rate-limit-worker/SKILL.md
@@ -5,10 +5,10 @@ metadata:
   wp-skills-author: "Soczó Kristóf"
   wp-skills-contact: "mailto:lonsdale201@hotmail.com"
   wp-skills-plugin: "lw-firewall"
-  wp-skills-plugin-version-tested: "1.5.4"
+  wp-skills-plugin-version-tested: "1.5.6"
   wp-skills-wp-version-tested: "7.1"
   wp-skills-php-min: "8.2"
-  wp-skills-last-updated: "2026-08-27"
+  wp-skills-last-updated: "2026-08-29"
 ---
 
 # LW Firewall rate-limit worker compatibility
@@ -22,42 +22,58 @@ before normal plugin callbacks.
 After bootstrap/version checks, the request path is:
 
 1. `LW_FIREWALL_DISABLE_WORKER` and master `enabled` exits.
-2. Server/localhost IP exemption.
-3. `ip_whitelist` exemption.
-4. `ip_blacklist` 403.
-5. Geo blocking.
-6. Existing shared-ban lookup, conditionally enabled as described below.
-7. 404-flood lookup.
-8. User-Agent bot blocking.
-9. Endpoint detection.
-10. Per-IP counter, 429/redirect, and optional violation escalation.
+2. Worker heartbeat transient (`lw_firewall_worker_alive`), written before any
+   decision so the Status tab can tell "installed" from "actually running".
+3. Server/localhost IP exemption.
+4. `ip_whitelist` exemption.
+5. `ip_blacklist` 403.
+6. Geo blocking.
+7. Storage resolution (memoized per request).
+8. Shared-ban lookup — **unconditional whenever the firewall is on** since 1.5.5.
+9. 404-flood lookup.
+10. User-Agent bot blocking.
+11. Endpoint detection.
+12. Per-IP counter, 429/redirect, and optional violation escalation.
 
 Whitelisting bypasses every later worker check. A blacklist or geo block runs
 before endpoint-specific code.
 
+The server-IP exemption covers `127.0.0.1`, `::1` and `SERVER_ADDR` only. Since
+1.5.6 the site's own hostname is deliberately **not** resolved into an
+exemption: `SERVER_NAME` comes from the client's `Host` header under Apache's
+default `UseCanonicalName Off`, so resolving it was a full bypass for any
+address an attacker could point a hostname at.
+
 ## Exact endpoint detection
 
-| Reason | v1.5.4 condition |
+Since 1.5.6 classification runs on the **decoded path**, never the raw URI.
+`lw_firewall_parse_uri()` splits path from query, `rawurldecode()`s the path,
+collapses repeated slashes and strips a trailing one; `lw_firewall_path_is()`
+then compares with `str_ends_with` so a subdirectory install's
+`/blog/wp-login.php` still matches.
+
+| Reason | v1.5.6 condition |
 |---|---|
-| `cron` | URI contains `/wp-cron.php`, `protect_cron`; requests containing `doing_wp_cron=` are exempt |
-| `xmlrpc` | URI contains `/xmlrpc.php`, `protect_xmlrpc` |
-| `login` | URI contains `/wp-login.php`, `protect_login` |
-| `rest` | URI contains `/wp-json/`, `protect_rest_api` |
+| `cron` | decoded path is/ends with `/wp-cron.php`, `protect_cron`; exempt only when `doing_wp_cron` is a query arg **on that path** |
+| `xmlrpc` | decoded path is/ends with `/xmlrpc.php`, `protect_xmlrpc` |
+| `login` | decoded path is/ends with `/wp-login.php`, `protect_login` |
+| `rest` | decoded path contains `/wp-json/` (bare `/wp-json` included) **or** a `rest_route` query arg is present, `protect_rest_api` |
 | `filter` | raw query string contains a configured `filter_params` substring |
 
-The cron exemption is not authenticated. In 1.5.4 any external request whose
-URI contains both `/wp-cron.php` and `doing_wp_cron=` is treated as a loopback
-and gets no endpoint limit. Because detection scans the complete raw URI in a
-fixed order, a protected REST URL can also add those strings in its query and
-return early before REST detection. Parse and compare the path plus the actual
-loopback trust boundary in regression tests; do not treat the current helper as
-proof that WordPress originated the request.
+This closes the 1.5.4 substring hole: `/wp-json/x?next=/wp-cron.php&doing_wp_cron=1`
+no longer escapes rate limiting, and `?redirect=/wp-login.php` is no longer
+billed to the login quota. Both REST shapes are now covered — the pretty
+`/wp-json/` prefix, the bare `/wp-json` index, and `?rest_route=/namespace/path`.
 
-The worker does not detect arbitrary pretty URLs, normal `admin-ajax.php`
-actions, route/method combinations, the bare REST index `/wp-json`, or
-WordPress REST URLs written as `?rest_route=/namespace/path`. A global REST
-toggle is coarse protection for a shared bucket, not registration blocking or
-route authorization.
+The cron loopback marker is still **not authenticated** — it is only a path-scoped
+`doing_wp_cron` presence check. It can no longer be used to skip classification
+on another endpoint, but do not treat it as proof that WordPress originated the
+request.
+
+The worker still does not detect arbitrary pretty URLs, normal `admin-ajax.php`
+actions, or route/method combinations. A global REST toggle is coarse
+protection for a shared bucket, not registration blocking or route
+authorization.
 
 ## Logged-in REST/filter bucket
 
@@ -131,81 +147,118 @@ must preserve a JSON error contract.
 
 Use `IpDetector::get_ip()` so companion counters agree with the worker.
 `CF-Connecting-IP` is trusted only when `REMOTE_ADDR` belongs to a known
-Cloudflare network. Do not independently trust `X-Forwarded-For`.
+Cloudflare network. Never independently trust `X-Forwarded-For`.
 
-That safe client-IP rule does not currently extend to geo detection:
-`GeoDetector` accepts any non-empty `CF-IPCountry` header without checking that
-`REMOTE_ADDR` is Cloudflare. On an origin reachable directly, a caller can send
-an allowed/invalid country header and skip CIDR fallback. Do not use the geo
-result as authorization, and close direct origin access when relying on the
-1.5.4 Cloudflare-header path.
+Since 1.5.6 that same trust test also gates geo: `GeoDetector` calls
+`IpDetector::is_cloudflare_request()` before reading `CF-IPCountry`, and the
+value must be exactly two letters (`XX`/`T1` fall through to the CIDR index).
+The 1.5.4 hole — any non-empty country header believed straight at the origin —
+is closed. Geo is still a signal, not authorization.
+
+**Reverse proxies (new in 1.5.6, opt-in).** Behind the common "nginx in front
+of Apache on the same host" layout every request arrived as `127.0.0.1`, which
+the server-IP exemption treated as the server itself: a silent, total bypass
+while the Status tab reported health. Configure trusted proxies under
+IP Rules → Reverse Proxy (`trusted_proxies`, `proxy_header`). `ProxyTrust`
+reads the forwarded chain right to left, skipping hops that are themselves
+trusted, and only after `REMOTE_ADDR` matches a configured proxy; the header
+name is restricted to `x-forwarded-for` / `x-real-ip` / `forwarded`. It stays
+opt-in because a forwarded header is client-controlled until the hop that set
+it is known. If a companion computes its own client IP, it must honour the same
+configuration or its counters will disagree with the worker's.
 
 Manual whitelist/blacklist values support individual IPv4/IPv6 addresses and
 CIDR ranges. Whitelist payment/webhook providers only when their published
 source ranges are stable and verified; whitelisting bypasses bot, geo, rate,
 404, and shared-ban checks too.
 
-## Verified v1.5.4 ban limitations
+## Ban enforcement (fixed in 1.5.5)
 
-- The worker looks up `ban_<ip>` only when `auto_ban_enabled` or
-  `login_limit_enabled` is true. Registration and password-reset code can write
-  a ban while both toggles are false, leaving the indexed ban unenforced.
-- Worker endpoint counters are named `<reason>_<ip>` and
-  `<reason>_li_<ip>`. `AutoBanner::unban()` clears `rl_<ip>` but not those
-  reason-specific keys, so an unbanned client can remain rate-limited until the
-  normal `rate_window` expires.
+Both 1.5.4 ban defects are gone:
 
-Account for these current behaviors in tests and operational runbooks. They
-are not reasons to duplicate or edit the worker from a companion plugin.
+- The worker now reads `ban_<ip>` **unconditionally whenever the firewall is
+  on**. Gating it on `auto_ban_enabled` / `login_limit_enabled` had left every
+  other producer — registration spam, password-reset floods, a manual CLI or
+  admin ban — writing a key nothing ever read, so the admin screen listed an
+  address as banned while it browsed the site freely.
+- `AutoBanner::unban()` now also clears the worker's per-endpoint counters, so
+  a released address is actually released instead of staying 429 until
+  `rate_window` aged out.
+- Ban durations are clamped: a zero duration used to mean "no TTL" to every
+  backend, i.e. an accidentally permanent ban.
+
+Still verify a real follow-up request rather than an index row — the storage
+key remains the sole authority on whether an IP is blocked.
 
 ## Configuration and backend boundaries
 
-`Options::get()` applies an `LW_FIREWALL_<KEY>` constant, but
-`Options::get_all()` does not. The worker and `Plugin::init_runtime_hooks()`
-read `get_all()` for their master/toggle/list decisions. Consequently several
-documented constant overrides—including the master `enabled`, endpoint
-toggles, IP lists, geo/bot lists and storage preference—do not change those
-paths in 1.5.4. `LW_FIREWALL_DISABLE_WORKER` is checked directly and remains a
-real worker kill switch. Test the effective request, not only `Options::get()`
-or a status screen.
+Since 1.5.5 `wp-config.php` constants reach the runtime. `Options::get_all()`
+layers `LW_FIREWALL_<KEY>` constants over the stored values, so the worker,
+`Plugin::init_runtime_hooks()`, the `.htaccess` sync and the status screen all
+see the pinned configuration — including the master `enabled` switch. The new
+`Options::get_stored()` is the editing/persistence view with no constant
+overlay, so saving never writes a pinned value into the database, and
+`Options::overridden()` lists the keys a constant currently pins (the settings
+screen labels those fields). `LW_FIREWALL_DISABLE_WORKER` is still checked
+directly and remains a real worker kill switch.
 
-The storage implementations do not currently provide identical semantics:
+The 1.5.4 storage-semantics divergences are fixed:
 
-- Redis and APCu keep a counter's TTL from its first hit; file storage extends
-  expiry on every increment, so sustained low-rate traffic can accumulate and
-  later block only on the file backend.
-- APCu's missing-key path uses `apcu_store()` rather than an atomic add/retry;
-  simultaneous first hits can overwrite one another and undercount a burst.
-- file storage has no expired-file sweep. Distinct IP/token keys leave expired
-  files until that exact key is read again, so inode use can grow without bound.
-- APCu/Redis keys use the global `lw_fw_` prefix without an installation/site
-  namespace; independent WordPress installs sharing the backend can collide.
-- file storage is node-local unless the directory is truly shared. It cannot
-  enforce one cluster-wide quota by itself.
+- The file backend counts in a **fixed window** like Redis and APCu.
+  Re-stamping expiry on every increment made it a sliding window, so the same
+  traffic banned on one backend and never banned on another. `increment()` is
+  an atomic read-modify-write under an exclusive lock.
+- APCu uses `apcu_add()` for the first hit, so concurrent first requests can no
+  longer overwrite one another and undercount the start of a burst.
+- Expired cache files are swept probabilistically with a batch cap
+  (`CacheDirectory::sweep()`), instead of only when the identical hashed key
+  was read again.
+- Guard files are written unconditionally and cover the geo sub-directory
+  (`CacheDirectory::protect()`).
+- Keys are namespaced per installation: `StorageDetector::key_prefix()` returns
+  `lw_fw_<md5(ABSPATH) first 8>_`. Two installs sharing one APCu/Redis pool no
+  longer collide. Note the seed is `ABSPATH`, so a **multisite network shares
+  one prefix** — buckets are per network, not per subsite.
+- The CIDR cache is written to a temp file and renamed, so a reader cannot see
+  a half-written include and fail open.
+
+Remaining backend caveat: file storage is node-local unless the directory is
+truly shared. It cannot enforce one cluster-wide quota by itself.
 
 For a security-sensitive companion, verify atomicity, TTL semantics, backend
 health, installation isolation and multi-node behavior in the deployment. Do
 not advertise backend-independent quotas until those checks pass.
 
-`lw_firewall_resolve_storage()` probes APCu/Redis before the worker knows
-whether the request has an endpoint limit, and a usable Redis path opens one
-connection for availability and another for the backend object. Cache or defer
-companion backend resolution; never add another probe loop on every page view.
+`lw_firewall_resolve_storage()` is memoized per request since 1.5.6 (a static
+map keyed by preference, delegating to `lw_firewall_build_storage()`), so
+repeated calls no longer re-run the availability probes or open a second Redis
+connection. A companion may call it freely; still never add its own probe loop
+on every page view.
 
-When `log_enabled` is on, each blocked request can rewrite the 100-row
-`lw_firewall_log` option. The cap bounds stored rows but not database writes;
-high-volume logging needs sampling/aggregation or an external append-oriented
-sink so the defense does not amplify a flood.
+When `log_enabled` is on, `Logger` collapses repeated IP/reason pairs for five
+minutes (`DEDUPE_WINDOW = 300`) into one counted entry, so a flood no longer
+rewrites the 100-row `lw_firewall_log` option on every blocked request. The
+write amplification is bounded, not eliminated: distinct IPs still each write.
+High-volume sites should still prefer an external append-oriented sink.
 
 ## Worker lifecycle
 
 - Activation copies `worker/lw-firewall-worker.php` to the MU-plugin directory.
 - Upgrade hooks replace it; deactivation removes it.
 - Version drift makes the worker bail and the main plugin attempts one repair.
-- The copied worker resolves classes from the literal
-  `WP_PLUGIN_DIR . '/lw-firewall/'` directory. Renaming the plugin directory can
-  make the worker return before registering while its version constant still
-  lets the main plugin regard the installed copy as current.
+- Since 1.5.6 `Activator::is_worker_outdated()` also compares **content**, not
+  only the version constant: an installed copy older than
+  `worker/lw-firewall-worker.php` by `filemtime` is replaced. A worker edited
+  without a version bump used to leave the stale copy running against new
+  plugin classes, which can fatal the site on a duplicate declaration.
+- The copied worker still resolves classes from the literal
+  `WP_PLUGIN_DIR . '/lw-firewall/'` directory, so renaming the plugin directory
+  makes it return before registering. Since 1.5.6 that is visible: the worker
+  writes a `lw_firewall_worker_alive` transient before any decision, and the
+  Status tab reports a worker that is installed but has never run
+  (`Activator::worker_last_seen()`). The version constant is defined before the
+  worker proves it can load anything, so it alone never was evidence.
+- `wp lw-firewall worker install|remove` drives the lifecycle from the CLI.
 - If the worker remains missing/outdated, the plugin does not register its
   normal runtime hooks, including registration, reset, 404 tracking, and
   security headers. Administrator monitoring is initialized separately.
@@ -218,7 +271,9 @@ Never edit the installed copy: lifecycle operations overwrite it.
 
 - Test anonymous and cookie-bearing REST/filter requests separately.
 - Test `/wp-json/`, bare `/wp-json`, and `?rest_route=` separately.
-- Test a REST URI carrying `/wp-cron.php` plus `doing_wp_cron=` in its query.
+- Test a REST URI carrying `/wp-cron.php` plus `doing_wp_cron=` in its query,
+  and percent-encoded / doubled-slash / trailing-slash spellings of each endpoint.
+- Test from behind a reverse proxy with and without `trusted_proxies` set.
 - Test limits with `protect_rest_api` on and off.
 - Exercise 429/`Retry-After`, filter redirect, and the endpoint's JSON contract.
 - Test current, missing, outdated, and emergency-disabled worker states.
@@ -228,6 +283,7 @@ Never edit the installed copy: lifecycle operations overwrite it.
   selectable storage backend.
 - Inspect expired file count and database writes during a distributed smoke load.
 - Verify constant overrides against a real worker request, not only an option read.
+- Verify the worker heartbeat after a plugin-directory rename.
 
 ## Cross-references
 
@@ -251,4 +307,12 @@ Never edit the installed copy: lifecycle operations overwrite it.
   - `includes/Rules/IpMatcher.php`
   - `includes/Storage/StorageInterface.php`
   - `includes/Storage/FileStorage.php`
+  - `includes/Storage/ApcuStorage.php`
+  - `includes/Storage/StorageDetector.php`
+  - `includes/Storage/CacheDirectory.php`
+  - `includes/ProxyTrust.php`
+  - `includes/OptionSchema.php`
+  - `includes/Logger.php`
+  - `includes/Geo/GeoDetector.php`
+  - `includes/CLI/WorkerCommand.php`
   - `CHANGELOG.md`

--- a/lw-plugins/lw-firewall-registration-guard/SKILL.md
+++ b/lw-plugins/lw-firewall-registration-guard/SKILL.md
@@ -5,10 +5,10 @@ metadata:
   wp-skills-author: "Soczó Kristóf"
   wp-skills-contact: "mailto:lonsdale201@hotmail.com"
   wp-skills-plugin: "lw-firewall"
-  wp-skills-plugin-version-tested: "1.5.4"
+  wp-skills-plugin-version-tested: "1.5.6"
   wp-skills-wp-version-tested: "7.1"
   wp-skills-php-min: "8.2"
-  wp-skills-last-updated: "2026-08-27"
+  wp-skills-last-updated: "2026-08-29"
 ---
 
 # LW Firewall registration guard
@@ -39,9 +39,15 @@ honour `users_can_register`.
 | Contract | Current behavior |
 |---|---|
 | `RegisterGuard::render_fields()` | Echoes `lw_fw_reg_token` and, when enabled, `lw_fw_url` |
-| `RegisterGuard::validate( WP_Error )` | Reads the current `$_POST`, records rejection, adds a generic error |
-| `RegisterToken::issue()` | Returns a signed timestamp token |
-| `RegisterToken::verify( $token, $min, $max, $storage, $scope )` | Checks signature, age and optional atomic single use |
+| `RegisterGuard::validate( $errors = null, $login = '', $email = '' )` | Reads the current `$_POST`, records rejection, adds a generic error |
+| `RegisterToken::issue( string $scope = 'reg' )` | Returns a signed per-render token |
+| `RegisterToken::make( int $issued, string $scope = 'reg', string $nonce = '' )` | Deterministic seam for tests |
+| `RegisterToken::verify( $token, $min, $max, ?$storage = null, $scope = 'reg' )` | Checks signature, scope, age and optional atomic single use |
+| `RegisterToken::check( $token, $now, $min, $max, ?$storage = null, $scope = 'reg' )` | Same, against an explicit "now" |
+
+`validate()` deliberately does **not** hard-type its first parameter (1.5.6):
+another plugin on `registration_errors` returning a non-`WP_Error` used to cause
+an uncatchable `TypeError` on a public form.
 | `RegisterTracker::record_reject()` | Counts non-whitelisted rejected registrations and may write a shared ban |
 
 `RegisterGuard`'s field constants and spam predicate are private. Do not call
@@ -100,9 +106,9 @@ anonymous signup and is not an authentication boundary.
 `/wp-json/`. It does not validate signup fields, authorize user creation, or
 target registration routes specifically. WordPress core's `wp/v2/users` create
 route requires `create_users`; a deliberately public custom registration route
-must implement its own permission policy and abuse controls. In v1.5.4 the
-bare `/wp-json` index and alternate `?rest_route=/...` URL form are not detected
-by the worker.
+must implement its own permission policy and abuse controls. Since 1.5.6 the
+worker also classifies the bare `/wp-json` index and the `?rest_route=/...`
+form, so those no longer slip past the REST bucket.
 
 ## Security meaning of the token
 
@@ -110,28 +116,36 @@ Keep normal CSRF, capability, authentication, validation, email-verification,
 and account-policy checks. The LW token is an anti-automation signal, not a
 WordPress nonce and not proof that a human submitted the form.
 
-In v1.5.4 the signed payload contains only the issue timestamp:
+Since 1.5.6 the signed payload is `v2.<issued>.<scope>.<nonce>` with 16 random
+bytes of per-render nonce:
 
-- it is not bound to form ID, route, user, IP, field name, or `$scope`;
-- `$scope` changes only the single-use storage key;
-- tokens issued in the same second are identical;
-- with single use enabled, two legitimate same-scope forms rendered in the
-  same second collide and the second submit is rejected;
-- a token accepted in one scope can also be accepted once in another scope;
-- the honeypot rejects a non-empty value, but an omitted honeypot is treated as
-  empty.
+- the **scope is signed**, so a token issued for one form is no longer accepted
+  by another — and `issue()` and `verify()` must be given the **same** scope
+  (both default to `'reg'`; a bare `issue()` verified against a custom scope
+  fails every time);
+- tokens issued in the same second are distinct, so two legitimate same-scope
+  renders no longer collide under single use, and a shared page cache no longer
+  hands one token to every visitor;
+- the format version is signed, so a token rendered by 1.5.4 fails on 1.5.6 —
+  expect rejections from cached pages right after the upgrade;
+- scope is normalized to `[a-z0-9_-]` after `strtolower()`, so `my form!` and
+  `myform` are the same scope;
+- it is still not bound to route, user, IP or field name;
+- the honeypot rejects a non-empty value, but an omitted honeypot is still
+  treated as empty.
 
-Treat these as verified 1.5.4 constraints. Do not describe the token as
-form-bound or unforgeable proof of user interaction.
+The token is now a per-render, form-bound proof of render. It is still not proof
+that a human submitted the form, and not a WordPress nonce.
 
-## Auto-ban caveat in 1.5.4
+## Auto-ban (fixed in 1.5.5)
 
 `RegisterTracker` writes `ban_<ip>` after `register_ban_threshold` failures.
-The MU worker currently checks shared ban keys only when either
-`auto_ban_enabled` or `login_limit_enabled` is on. A registration-only default
-configuration can therefore list a `register_spam` ban without enforcing it on
-the next request. Do not promise site-wide blocking without testing the actual
-settings and worker behavior.
+The 1.5.4 defect — the worker reading shared ban keys only when
+`auto_ban_enabled` or `login_limit_enabled` was on, so a registration-only
+configuration listed a `register_spam` ban it never enforced — is fixed: the
+worker now reads the ban key whenever the firewall is enabled. Still confirm
+enforcement with a real follow-up request; the storage key, not the index row,
+is the authority.
 
 ## Review checklist
 

--- a/lw-plugins/lw-firewall-registration-guard/references/registration-and-rest-integration.md
+++ b/lw-plugins/lw-firewall-registration-guard/references/registration-and-rest-integration.md
@@ -1,6 +1,6 @@
 # Registration and REST integration contract
 
-This reference is verified against LW Firewall 1.5.4 and WordPress 7.1.
+This reference is verified against LW Firewall 1.5.6 and WordPress 7.1.
 
 ## Transport-independent validator
 
@@ -113,15 +113,19 @@ $bootstrap['lwFirewall'] = [
         && (bool) Options::get('enabled', true)
         && (bool) Options::get('register_protect_enabled', true),
     'tokenName' => 'lw_fw_reg_token',
-    'token' => class_exists(RegisterToken::class) ? RegisterToken::issue() : '',
+    // Scope is signed into the token since 1.5.6; issue and verify must agree.
+    // 'reg' is the built-in registration scope used by verify() below.
+    'token' => class_exists(RegisterToken::class) ? RegisterToken::issue('reg') : '',
     'honeypotName' => 'lw_fw_url',
     'honeypotEnabled' => (bool) Options::get('register_honeypot', true),
 ];
 ```
 
 Do not cache a single token into a shared page or CDN response when single-use
-is enabled. Every visitor receiving the cached value would contend for the same
-replay key. Mark the bootstrap private/no-store or fetch it per session/request.
+is enabled. 1.5.6's per-render nonce makes two *renders* distinct, but a cached
+page is one render served many times, so every visitor still contends for the
+same replay key. Mark the bootstrap private/no-store or fetch it per
+session/request.
 
 ## Route-local rate limit
 
@@ -153,7 +157,10 @@ namespace unique; never reuse worker keys such as `rest_<ip>`.
 2. Missing token and invalid signature.
 3. Token younger than the fill-time floor and older than the maximum age.
 4. First and second use with single use enabled.
-5. Two tokens issued in the same second and submitted by different clients.
+5. Two tokens issued in the same second and submitted by different clients
+   (both must succeed since 1.5.6).
+5b. A token issued under a different scope (must fail), and a pre-1.5.6 token
+   (must fail closed).
 6. Filled honeypot; optionally missing honeypot if the adapter requires presence.
 7. Plugin inactive, master disabled, registration guard disabled, worker outdated.
 8. Route-local limit and generic error response.

--- a/skills-index.json
+++ b/skills-index.json
@@ -3747,10 +3747,10 @@
         "author": "Soczó Kristóf",
         "contact": "mailto:lonsdale201@hotmail.com",
         "plugin": "lw-firewall",
-        "plugin-version-tested": "1.5.4",
+        "plugin-version-tested": "1.5.6",
         "wp-version-tested": "7.1",
         "php-min": "8.2",
-        "last-updated": "2026-08-27"
+        "last-updated": "2026-08-29"
       },
       "resources": [
         {
@@ -3764,24 +3764,24 @@
           "path": "references/generic-form-guard-proposal.md",
           "repo_path": "lw-plugins/lw-firewall-custom-form-adapter/references/generic-form-guard-proposal.md",
           "type": "reference",
-          "bytes": 6110,
-          "sha256": "a4bafac4f65372448d5916dd1ac1213412409bb57ff31a39f978b4f5f7238e71"
+          "bytes": 6492,
+          "sha256": "c04265232c616bbaa65f7ac9eef3fc791f0224a061f1d40e11e88fa2e62730fa"
         }
       ],
       "has_reference": true,
       "has_examples": false,
       "has_scripts": false,
       "skill_md": {
-        "bytes": 9363,
-        "lines": 217,
-        "sha256": "4772159bcd1eb23f1921fc01ebbd507f8e1e55dbc6f7c4de5f8e4800f97ce3f2"
+        "bytes": 10681,
+        "lines": 236,
+        "sha256": "22981e612bfaca1c715c5e3901677197a00aa57c1d0a34249de759c1656445aa"
       }
     },
     {
       "slug": "lw-firewall-management-abilities",
       "name": "lw-firewall-management-abilities",
       "domain": "lw-plugins",
-      "description": "Manage and audit LW Firewall 1.5.4 through its options API, admin UI, WP-CLI, LW Site Manager abilities, worker controls, logs, administrator alerts, password-reset settings, and manual or automatic IP bans. Use when code or runbooks reference `wp lw-firewall`, `Options::save`, `LW_FIREWALL_*`, `lw-firewall/get-options`, `block-ip`, `lw_firewall_bans`, `BanList`, `AutoBanner::unban`, worker reinstall, alert baseline, reset protection, import/export, or firewall configuration migration.",
+      "description": "Manage and audit LW Firewall 1.5.6 through its options API, admin UI, WP-CLI, LW Site Manager abilities, worker controls, logs, administrator alerts, password-reset settings, and manual or automatic IP bans. Use when code or runbooks reference `wp lw-firewall`, `Options::save`, `LW_FIREWALL_*`, `lw-firewall/get-options`, `block-ip`, `lw_firewall_bans`, `BanList`, `AutoBanner::unban`, worker reinstall, alert baseline, reset protection, import/export, or firewall configuration migration.",
       "path": "lw-plugins/lw-firewall-management-abilities",
       "skill_path": "lw-plugins/lw-firewall-management-abilities/SKILL.md",
       "url": "https://raw.githubusercontent.com/Lonsdale201/wp-agent-skills/main/lw-plugins/lw-firewall-management-abilities/SKILL.md",
@@ -3792,10 +3792,10 @@
         "author": "Soczó Kristóf",
         "contact": "mailto:lonsdale201@hotmail.com",
         "plugin": "lw-firewall",
-        "plugin-version-tested": "1.5.4",
+        "plugin-version-tested": "1.5.6",
         "wp-version-tested": "7.1",
         "php-min": "8.2",
-        "last-updated": "2026-08-27"
+        "last-updated": "2026-08-29"
       },
       "resources": [
         {
@@ -3810,9 +3810,9 @@
       "has_examples": false,
       "has_scripts": false,
       "skill_md": {
-        "bytes": 11657,
-        "lines": 248,
-        "sha256": "7474472f7196cd1ce3731ee1f77e3c6e7b5c1b008ee77a51efc7716a3b685442"
+        "bytes": 14235,
+        "lines": 295,
+        "sha256": "f0b67b01a4c558f4a117597c888b4fc3a423ed181ae3aefba7ff8f4c2d2df0da"
       }
     },
     {
@@ -3830,10 +3830,10 @@
         "author": "Soczó Kristóf",
         "contact": "mailto:lonsdale201@hotmail.com",
         "plugin": "lw-firewall",
-        "plugin-version-tested": "1.5.4",
+        "plugin-version-tested": "1.5.6",
         "wp-version-tested": "7.1",
         "php-min": "8.2",
-        "last-updated": "2026-08-27"
+        "last-updated": "2026-08-29"
       },
       "resources": [
         {
@@ -3848,9 +3848,9 @@
       "has_examples": false,
       "has_scripts": false,
       "skill_md": {
-        "bytes": 8154,
-        "lines": 177,
-        "sha256": "c8faeb6190289ae9a8a85f042145bec275db8384f376959ae913084ce7e55b7d"
+        "bytes": 8977,
+        "lines": 194,
+        "sha256": "2b6d37dec752fbe49186033c8875890b881551e13c58f86ef86c32885085e131"
       }
     },
     {
@@ -3868,10 +3868,10 @@
         "author": "Soczó Kristóf",
         "contact": "mailto:lonsdale201@hotmail.com",
         "plugin": "lw-firewall",
-        "plugin-version-tested": "1.5.4",
+        "plugin-version-tested": "1.5.6",
         "wp-version-tested": "7.1",
         "php-min": "8.2",
-        "last-updated": "2026-08-27"
+        "last-updated": "2026-08-29"
       },
       "resources": [
         {
@@ -3886,9 +3886,9 @@
       "has_examples": false,
       "has_scripts": false,
       "skill_md": {
-        "bytes": 11820,
-        "lines": 255,
-        "sha256": "607cf3e599f8a8f28b48af40733b2325a2af417368ab1104e537620521eb49e4"
+        "bytes": 15700,
+        "lines": 319,
+        "sha256": "94deab03ea7cee73b682678d24914d936e8b0cbf138252c4d222d47779a46981"
       }
     },
     {
@@ -3906,10 +3906,10 @@
         "author": "Soczó Kristóf",
         "contact": "mailto:lonsdale201@hotmail.com",
         "plugin": "lw-firewall",
-        "plugin-version-tested": "1.5.4",
+        "plugin-version-tested": "1.5.6",
         "wp-version-tested": "7.1",
         "php-min": "8.2",
-        "last-updated": "2026-08-27"
+        "last-updated": "2026-08-29"
       },
       "resources": [
         {
@@ -3923,17 +3923,17 @@
           "path": "references/registration-and-rest-integration.md",
           "repo_path": "lw-plugins/lw-firewall-registration-guard/references/registration-and-rest-integration.md",
           "type": "reference",
-          "bytes": 6133,
-          "sha256": "b90390e72f3874cc8581dffa14eb5062d16ff12a902ceebe9228d4777179dffa"
+          "bytes": 6509,
+          "sha256": "17ce46a2f333ee5f1326772636cb1ae3e767c7f3b1c8998c8043c2a030b60dd5"
         }
       ],
       "has_reference": true,
       "has_examples": false,
       "has_scripts": false,
       "skill_md": {
-        "bytes": 7307,
-        "lines": 169,
-        "sha256": "02774a35a96eb92d2cadaa5247a3489b70a3c34caaf6786d542489b2e0983c44"
+        "bytes": 8370,
+        "lines": 183,
+        "sha256": "fc6516bebf1ca4a717259db32931d9de14d12dfe488b0b37ab0355eed4f0ce6a"
       }
     },
     {


### PR DESCRIPTION
Re-grounds the five `lw-firewall-*` skills from 1.5.4 to **1.5.6**. Verified against the 1.5.6 source, not the changelog alone.

1.5.5 and 1.5.6 were security-audit releases: most of what the 1.5.4 grounding documented as *current defects* is now fixed, and one public contract changed in a way that silently breaks adapters.

### Breaking contract change — `RegisterToken` v2

The payload is now `v2.<issued>.<scope>.<nonce>` with a 16-byte per-render nonce, and **the scope is signed** rather than only prefixing the replay key.

- `issue()` and `verify()` must be given the **same** scope. Both default to `'reg'`, so an adapter calling a bare `issue()` and verifying with its own scope now fails **every** submission. The `custom-form-adapter` example did exactly this — fixed.
- Same-second renders are now distinct, so the single-use collision and the shared-page-cache problem are gone.
- The format version is signed, so pre-1.5.6 tokens fail closed (expect rejections from cached pages right after an upgrade).
- Scope is normalized to `[a-z0-9_-]` after `strtolower()`.
- `RegisterGuard::validate()` no longer hard-types its first parameter.

### Corrected — previously documented as broken

- Endpoint classification runs on the **decoded path**; the raw-URI substring hole and the unscoped cron-loopback marker are gone, and both bare `/wp-json` and `?rest_route=` are detected.
- The ban key is read whenever the firewall is on, and `unban()` clears the worker's per-endpoint counters.
- `wp-config.php` constants reach the runtime via `Options::get_all()`; adds `get_stored()` and `overridden()`.
- `OptionSchema` is the central server-side value policy `Options::save()` applies — this closes the gap the skill described as *"until a central option schema exists"*.
- Storage parity: file backend is a fixed window, APCu uses `apcu_add()`, expired files are swept, keys are namespaced per installation.
- Geo requires the Cloudflare trust test; the reset email quota is charged last; `reset_block_admins` covers every privileged account, not just the role slug.
- Alerts are retried via `AlertQueue`; the log collapses repeats for five minutes.
- `IpMatcher` rejects malformed CIDR prefixes instead of matching every address in the family.

### Added / removed

Added: reverse-proxy trust (`ProxyTrust`, `trusted_proxies` / `proxy_header`), worker heartbeat and content-based self-heal, `wp lw-firewall worker`. Removed: `geo_action`.

### Still-open items, deliberately kept

- The logged-in rate-limit bucket matches the cookie by shape (upstream: known, not fixed).
- `reset_block_admins` allows administrator enumeration (upstream: known, not fixed).
- The Site Manager ability's own CIDR validator still accepts a malformed suffix. Now **inert** — `IpMatcher` refuses to match it — but it is a rule an operator believes is active and is not.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)