### PR TITLE
lw-plugins: fix two stale 1.5.4 claims left in the custom-form adapter

### DIFF
--- a/lw-plugins/lw-firewall-custom-form-adapter/SKILL.md
+++ b/lw-plugins/lw-firewall-custom-form-adapter/SKILL.md
@@ -138,10 +138,12 @@ final class MyFormProof
 }
 ```
 
-`SCOPE` must be a developer-owned constant, never request input. It separates
-the atomic replay counter but does not bind the signature. Own timing values in
-the companion plugin; borrowing `register_*` options silently couples unrelated
-forms to registration policy.
+`SCOPE` must be a developer-owned constant, never request input. Since 1.5.6 it
+is signed into the token as well as namespacing the atomic replay counter, so it
+genuinely binds the proof to this form — which is also why `issue()` and
+`verify()` must receive the identical value. Own timing values in the companion
+plugin; borrowing `register_*` options silently couples unrelated forms to
+registration policy.
 
 ## Rendering and transport
 
@@ -161,9 +163,11 @@ with a form-specific key and `IpDetector::get_ip()`. Return the transport's own
 generic 429 contract rather than calling `RateLimiter::too_many()` when a JSON
 envelope is required.
 
-The global `protect_rest_api` toggle is shared across all detected `/wp-json/`
-traffic, does not recognize `?rest_route=`, and does not know which route
-submits this form.
+The global `protect_rest_api` toggle is shared across all detected REST traffic
+— since 1.5.6 that includes the pretty `/wp-json/` prefix, the bare `/wp-json`
+index and the `?rest_route=` form — but it is one shared bucket and does not
+know which route submits this form. It is not a substitute for a form-specific
+limit.
 
 `RateLimiter::is_allowed_key()` overrides the count limit only. Its window
 still comes from the global `rate_window` option. A companion that needs an

--- a/skills-index.json
+++ b/skills-index.json
@@ -3772,9 +3772,9 @@
       "has_examples": false,
       "has_scripts": false,
       "skill_md": {
-        "bytes": 10681,
-        "lines": 236,
-        "sha256": "22981e612bfaca1c715c5e3901677197a00aa57c1d0a34249de759c1656445aa"
+        "bytes": 10979,
+        "lines": 240,
+        "sha256": "15cda0c7cffaaa61c8b2d1ff5469dd1cb3d587dd6fb404ea08a069b6a41852d5"
       }
     },
     {


### PR DESCRIPTION
Follow-up to #11. Two sentences survived the 1.5.6 re-grounding and now contradict what the same file says elsewhere:

| Line | Was | Is |
|---|---|---|
| `SCOPE` paragraph | *"separates the atomic replay counter but does not bind the signature"* | since 1.5.6 the scope **is** signed into the payload — which is precisely why `issue()` and `verify()` must receive the identical value |
| Separate rate limit | *"does not recognize `?rest_route=`"* | since 1.5.6 it does, along with the bare `/wp-json` index; the real caveat is that it stays one shared bucket with no per-route knowledge |

Both are corrected against the 1.5.6 source (`RegisterToken::payload()`, `lw_firewall_detect_type()`), and `skills-index.json` is regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)